### PR TITLE
ci: fix TODOs blocked by repos being private

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,7 +1,6 @@
 name: "Lint PR Title"
 
 on:
-  # TODO: Change to pull_request_target after the repo is public.
   pull_request:
     types:
       - opened


### PR DESCRIPTION
*Description of changes:*
PR fixes the TODOs by repos being private

Reference: https://github.com/amannn/action-semantic-pull-request/issues/219

*Testing done:*
N/A



- [ X ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.