### PR TITLE
refactor!: StdOut,StdErr -> Stdout,Stderr

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -139,33 +139,33 @@ func RunWithoutSuccessfulExit(o *option.Option, args ...string) *gexec.Session {
 	return New(o, args...).WithoutSuccessfulExit().Run()
 }
 
-// StdOut invokes Run and returns the stdout.
-func StdOut(o *option.Option, args ...string) []byte {
+// Stdout invokes Run and returns the stdout.
+func Stdout(o *option.Option, args ...string) []byte {
 	return Run(o, args...).Out.Contents()
 }
 
 // StdoutStr invokes Run and returns the output in string format.
 func StdoutStr(o *option.Option, args ...string) string {
-	return strings.TrimSpace(string(StdOut(o, args...)))
+	return strings.TrimSpace(string(Stdout(o, args...)))
 }
 
-// StdOutAsLines invokes Run and returns the stdout as lines.
-func StdOutAsLines(o *option.Option, args ...string) []string {
+// StdoutAsLines invokes Run and returns the stdout as lines.
+func StdoutAsLines(o *option.Option, args ...string) []string {
 	return toLines(Run(o, args...).Out)
 }
 
-// StdErr invokes Run and returns the stderr.
-func StdErr(o *option.Option, args ...string) []byte {
+// Stderr invokes Run and returns the stderr.
+func Stderr(o *option.Option, args ...string) []byte {
 	return Run(o, args...).Err.Contents()
 }
 
-// StdErrAsLines invokes Run and returns the stderr as lines.
-func StdErrAsLines(o *option.Option, args ...string) []string {
+// StderrAsLines invokes Run and returns the stderr as lines.
+func StderrAsLines(o *option.Option, args ...string) []string {
 	return toLines(Run(o, args...).Err)
 }
 
-// StdErrStr invokes Run and returns the output in string format.
-func StdErrStr(o *option.Option, args ...string) string {
+// StderrStr invokes Run and returns the output in string format.
+func StderrStr(o *option.Option, args ...string) string {
 	return string(Run(o, args...).Err.Contents())
 }
 

--- a/command/get.go
+++ b/command/get.go
@@ -9,25 +9,25 @@ import (
 
 // GetAllContainerIDs returns all container IDs.
 func GetAllContainerIDs(o *option.Option) []string {
-	return StdOutAsLines(o, "ps", "--all", "--quiet", "--no-trunc")
+	return StdoutAsLines(o, "ps", "--all", "--quiet", "--no-trunc")
 }
 
 // GetAllImageNames returns all image names.
 func GetAllImageNames(o *option.Option) []string {
-	return StdOutAsLines(o, "images", "--all", "--format", "{{.Repository}}:{{.Tag}}")
+	return StdoutAsLines(o, "images", "--all", "--format", "{{.Repository}}:{{.Tag}}")
 }
 
 // GetAllVolumeNames returns all volume names.
 func GetAllVolumeNames(o *option.Option) []string {
-	return StdOutAsLines(o, "volume", "ls", "--quiet")
+	return StdoutAsLines(o, "volume", "ls", "--quiet")
 }
 
 // GetAllNetworkNames returns all network names.
 func GetAllNetworkNames(o *option.Option) []string {
-	return StdOutAsLines(o, "network", "ls", "--format", "{{.Name}}")
+	return StdoutAsLines(o, "network", "ls", "--format", "{{.Name}}")
 }
 
 // GetAllImageIDs returns all image IDs.
 func GetAllImageIDs(o *option.Option) []string {
-	return StdOutAsLines(o, "images", "--all", "--quiet")
+	return StdoutAsLines(o, "images", "--all", "--quiet")
 }

--- a/tests/build.go
+++ b/tests/build.go
@@ -58,7 +58,7 @@ func Build(o *option.Option) {
 				for _, file := range []string{"-f", "--file"} {
 					file := file
 					ginkgo.It(fmt.Sprintf("build an image with %s option", file), func() {
-						stdErr := command.StdErr(o, "build", "--no-cache", file, dockerFilePath, buildContext)
+						stdErr := command.Stderr(o, "build", "--no-cache", file, dockerFilePath, buildContext)
 						gomega.Expect(stdErr).Should(gomega.ContainSubstring("built from AnotherDockerfile"))
 					})
 				}
@@ -73,7 +73,7 @@ func Build(o *option.Option) {
 				secretFile := filepath.Join(buildContext, "secret.txt")
 				ffs.WriteFile(secretFile, "somesecret")
 				secret := fmt.Sprintf("id=mysecret,src=%s", secretFile)
-				stdErr := command.StdErr(o, "build", "--progress=plain", "--no-cache", "-f", dockerFilePath, "--secret", secret, buildContext)
+				stdErr := command.Stderr(o, "build", "--progress=plain", "--no-cache", "-f", dockerFilePath, "--secret", secret, buildContext)
 				gomega.Expect(stdErr).Should(gomega.ContainSubstring("somesecret"))
 			})
 
@@ -85,7 +85,7 @@ func Build(o *option.Option) {
 			`, defaultImage, defaultImage)
 				dockerFilePath := filepath.Join(buildContext, "Dockerfile.with-target")
 				ffs.WriteFile(dockerFilePath, containerWithTarget)
-				stdEr := command.StdErr(o, "build", "--progress=plain", "--no-cache",
+				stdEr := command.Stderr(o, "build", "--progress=plain", "--no-cache",
 					"-f", dockerFilePath, "--target", "build_env", buildContext)
 				gomega.Expect(stdEr).Should(gomega.ContainSubstring("output from build_env"))
 				gomega.Expect(stdEr).ShouldNot(gomega.ContainSubstring("output from prod_env"))
@@ -101,7 +101,7 @@ func Build(o *option.Option) {
 				containerWithBuildArg := "ARG VERSION=latest \n FROM public.ecr.aws/docker/library/alpine:${VERSION}"
 				dockerFilePath := filepath.Join(buildContext, "Dockerfile.with-build-arg")
 				ffs.WriteFile(dockerFilePath, containerWithBuildArg)
-				stdErr := command.StdErr(o, "build", "-f", dockerFilePath, "--no-cache", "--progress=plain",
+				stdErr := command.Stderr(o, "build", "-f", dockerFilePath, "--no-cache", "--progress=plain",
 					"--build-arg", "VERSION=3.13", buildContext)
 				gomega.Expect(stdErr).Should(gomega.ContainSubstring("public.ecr.aws/docker/library/alpine:3.13"))
 			})
@@ -112,7 +112,7 @@ func Build(o *option.Option) {
 			`, defaultImage)
 				dockerFilePath := filepath.Join(buildContext, "Dockerfile.progress")
 				ffs.WriteFile(dockerFilePath, dockerFile)
-				stdErr := command.StdErr(o, "build", "-f", dockerFilePath, "--no-cache", "--progress=plain", buildContext)
+				stdErr := command.Stderr(o, "build", "-f", dockerFilePath, "--no-cache", "--progress=plain", buildContext)
 				gomega.Expect(stdErr).Should(gomega.ContainSubstring("progress flag set:2"))
 			})
 

--- a/tests/compose_build.go
+++ b/tests/compose_build.go
@@ -45,7 +45,7 @@ func ComposeBuild(o *option.Option) {
 		})
 
 		ginkgo.It("should output progress in plain text format", func() {
-			composeBuildOutput := command.StdErrStr(o, "compose", "build", "--progress",
+			composeBuildOutput := command.StderrStr(o, "compose", "build", "--progress",
 				"plain", "--no-cache", "--file", composeFilePath)
 			// The docker file contains following command.
 			// RUN printf 'should only see the final answer when "--progress" is set to be "plain": %d\n' $(expr 1 + 1)

--- a/tests/compose_logs.go
+++ b/tests/compose_logs.go
@@ -37,7 +37,7 @@ func ComposeLogs(o *option.Option) {
 			command.RemoveAll(o)
 		})
 		ginkgo.It("should show the logs with prefixes", func() {
-			output := command.StdOutAsLines(o, "compose", "logs", "--file", composeFilePath)
+			output := command.StdoutAsLines(o, "compose", "logs", "--file", composeFilePath)
 			// Log format: container_name |log_msg
 			// example: container1_composelogs |hello from service 1
 			gomega.Expect(output).Should(gomega.ContainElements(
@@ -45,7 +45,7 @@ func ComposeLogs(o *option.Option) {
 				gomega.HavePrefix(containerNames[1])))
 		})
 		ginkgo.It("should show the logs without prefixes", func() {
-			output := command.StdOutAsLines(o, "compose", "logs", "--no-log-prefix", "--file", composeFilePath)
+			output := command.StdoutAsLines(o, "compose", "logs", "--no-log-prefix", "--file", composeFilePath)
 			// Log format: log_msg
 			// example: hello from service 1
 			gomega.Expect(output).ShouldNot(gomega.ContainElements(
@@ -58,7 +58,7 @@ func ComposeLogs(o *option.Option) {
 			gomega.Expect(output).ShouldNot(gomega.ContainSubstring("\x1b[3"))
 		})
 		ginkgo.It("should show the last line of the logs", func() {
-			output := command.StdOutAsLines(o, "compose", "logs", services[0], "--tail", "1", "--file", composeFilePath)
+			output := command.StdoutAsLines(o, "compose", "logs", services[0], "--tail", "1", "--file", composeFilePath)
 			gomega.Expect(output).Should(gomega.HaveLen(1))
 		})
 
@@ -67,7 +67,7 @@ func ComposeLogs(o *option.Option) {
 			ginkgo.It(fmt.Sprintf("should show the logs with timestamp with no prefixes and no color [flag %s]", tFlag), func() {
 				// Log format: YYYY-MM-DDThh:mm:ss.000000000Z LOG MSG
 				timestampMatcher := gomega.MatchRegexp("^[0-9]{1,4}-[0-9]{1,2}-[0-9]{1,2}T[0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2}.*")
-				output := command.StdOutAsLines(o, "compose", "logs", tFlag, "--no-log-prefix", "--no-color", "--file", composeFilePath)
+				output := command.StdoutAsLines(o, "compose", "logs", tFlag, "--no-log-prefix", "--no-color", "--file", composeFilePath)
 				gomega.Expect(output).Should(gomega.HaveEach(timestampMatcher))
 			})
 		}

--- a/tests/compose_ps.go
+++ b/tests/compose_ps.go
@@ -36,7 +36,7 @@ func ComposePs(o *option.Option) {
 			command.RemoveAll(o)
 		})
 		ginkgo.It("should list services defined in compose file", func() {
-			psOutput := command.StdOutAsLines(o, "compose", "ps", "--file", composeFilePath)
+			psOutput := command.StdoutAsLines(o, "compose", "ps", "--file", composeFilePath)
 			gomega.Expect(psOutput).Should(gomega.ContainElements(
 				gomega.ContainSubstring(services[0]),
 				gomega.ContainSubstring(services[1])))

--- a/tests/exec.go
+++ b/tests/exec.go
@@ -70,7 +70,7 @@ func Exec(o *option.Option) {
 				env := env
 				ginkgo.It(fmt.Sprintf("should set the environment variable with %s flag", env), func() {
 					const envPair = "ENV=1"
-					lines := command.StdOutAsLines(o, "exec", env, envPair, testContainerName, "env")
+					lines := command.StdoutAsLines(o, "exec", env, envPair, testContainerName, "env")
 					gomega.Expect(lines).Should(gomega.ContainElement(envPair))
 				})
 			}
@@ -80,7 +80,7 @@ func Exec(o *option.Option) {
 				envPath := ffs.CreateTempFile("env", envPair)
 				ginkgo.DeferCleanup(os.RemoveAll, filepath.Dir(envPath))
 
-				envOutput := command.StdOutAsLines(o, "exec", "--env-file", envPath, testContainerName, "env")
+				envOutput := command.StdoutAsLines(o, "exec", "--env-file", envPath, testContainerName, "env")
 				gomega.Expect(envOutput).Should(gomega.ContainElement(envPair))
 			})
 

--- a/tests/image_history.go
+++ b/tests/image_history.go
@@ -36,13 +36,13 @@ func ImageHistory(o *option.Option) {
 		for _, quiet := range []string{"-q", "--quiet"} {
 			quiet := quiet
 			ginkgo.It(fmt.Sprintf("should only display snapshot ID with %s flag", quiet), func() {
-				ids := removeMissingID(command.StdOutAsLines(o, "image", "history", quiet, defaultImage))
+				ids := removeMissingID(command.StdoutAsLines(o, "image", "history", quiet, defaultImage))
 				gomega.Expect(ids).Should(gomega.HaveEach(gomega.MatchRegexp(sha256RegexFull)))
 			})
 		}
 
 		ginkgo.It("should only display snapshot ID with --format flag", func() {
-			ids := removeMissingID(command.StdOutAsLines(o, "image", "history", defaultImage, "--format", "{{.Snapshot}}"))
+			ids := removeMissingID(command.StdoutAsLines(o, "image", "history", defaultImage, "--format", "{{.Snapshot}}"))
 			gomega.Expect(ids).Should(gomega.HaveEach(gomega.MatchRegexp(sha256RegexFull)))
 		})
 

--- a/tests/image_inspect.go
+++ b/tests/image_inspect.go
@@ -33,7 +33,7 @@ func ImageInspect(o *option.Option) {
 
 		ginkgo.It("should display multiple image RepoTags with --format flag", func() {
 			pullImage(o, olderAlpineImage)
-			lines := command.StdOutAsLines(o, "image", "inspect", defaultImage, olderAlpineImage, "--format", "{{(index .RepoTags 0)}}")
+			lines := command.StdoutAsLines(o, "image", "inspect", defaultImage, olderAlpineImage, "--format", "{{(index .RepoTags 0)}}")
 			gomega.Expect(lines).Should(gomega.ConsistOf(defaultImage, olderAlpineImage))
 		})
 

--- a/tests/images.go
+++ b/tests/images.go
@@ -27,7 +27,7 @@ func Images(o *option.Option) {
 		})
 
 		ginkgo.It("should list all the images in a tabular format", func() {
-			images := command.StdOutAsLines(o, "images")
+			images := command.StdoutAsLines(o, "images")
 			header, images := images[0], images[1:]
 			gomega.Expect(images).ShouldNot(gomega.BeEmpty())
 			gomega.Expect(header).Should(gomega.MatchRegexp(
@@ -36,7 +36,7 @@ func Images(o *option.Option) {
 			// TODO: add more strict validation using output matcher.
 		})
 		ginkgo.It("should list all the images with image names in a tabular format ", func() {
-			images := command.StdOutAsLines(o, "images", "--names")
+			images := command.StdoutAsLines(o, "images", "--names")
 			header, images := images[0], images[1:]
 			gomega.Expect(images).ShouldNot(gomega.BeEmpty())
 			gomega.Expect(header).Should(gomega.MatchRegexp("NAME[\t ]+IMAGE ID[\t ]+CREATED[\t ]+PLATFORM[\t ]+SIZE[\t ]+BLOB SIZE"))
@@ -44,23 +44,23 @@ func Images(o *option.Option) {
 			// TODO: add more strict validation using output matcher.
 		})
 		ginkgo.It("should list all the images", func() {
-			images := command.StdOutAsLines(o, "images", "--format", "{{.Repository}}:{{.Tag}}")
+			images := command.StdoutAsLines(o, "images", "--format", "{{.Repository}}:{{.Tag}}")
 			gomega.Expect(images).ShouldNot(gomega.BeEmpty())
 			gomega.Expect(images).Should(gomega.ContainElements(testImageName))
 			gomega.Expect(images).Should(gomega.ContainElements(defaultImage))
 		})
 		ginkgo.It("should list truncated IMAGE IDs", func() {
-			images := command.StdOutAsLines(o, "images", "--quiet")
+			images := command.StdoutAsLines(o, "images", "--quiet")
 			gomega.Expect(images).ShouldNot(gomega.BeEmpty())
 			gomega.Expect(images).Should(gomega.HaveEach(gomega.MatchRegexp(sha256RegexTruncated)))
 		})
 		ginkgo.It("should list full IMAGE IDs", func() {
-			images := command.StdOutAsLines(o, "images", "--quiet", "--no-trunc")
+			images := command.StdoutAsLines(o, "images", "--quiet", "--no-trunc")
 			gomega.Expect(images).ShouldNot(gomega.BeEmpty())
 			gomega.Expect(images).Should(gomega.HaveEach(gomega.MatchRegexp(sha256RegexFull)))
 		})
 		ginkgo.It("should list IMAGE digests", func() {
-			images := command.StdOutAsLines(o, "images", "--digests", "--format", "{{.Digest}}")
+			images := command.StdoutAsLines(o, "images", "--digests", "--format", "{{.Digest}}")
 			gomega.Expect(images).ShouldNot(gomega.BeEmpty())
 			gomega.Expect(images).Should(gomega.HaveEach(gomega.MatchRegexp(sha256RegexFull)))
 		})

--- a/tests/inspect.go
+++ b/tests/inspect.go
@@ -33,7 +33,7 @@ func Inspect(o *option.Option) {
 			const oldContainerName = "ctr-old"
 			command.Run(o, "run", "--name", testContainerName, defaultImage)
 			command.Run(o, "run", "--name", oldContainerName, olderAlpineImage)
-			images := command.StdOutAsLines(o, "inspect", "--format", "{{.Image}}", testContainerName, oldContainerName)
+			images := command.StdoutAsLines(o, "inspect", "--format", "{{.Image}}", testContainerName, oldContainerName)
 			gomega.Expect(images).Should(gomega.ConsistOf(defaultImage, olderAlpineImage))
 		})
 

--- a/tests/network_inspect.go
+++ b/tests/network_inspect.go
@@ -28,7 +28,7 @@ func NetworkInspect(o *option.Option) {
 
 		ginkgo.It("should display detailed information on multiple networks", func() {
 			command.Run(o, "network", "create", testNetwork)
-			lines := command.StdOutAsLines(o, "network", "inspect", bridgeNetwork, testNetwork, "--format", "{{.Name}}")
+			lines := command.StdoutAsLines(o, "network", "inspect", bridgeNetwork, testNetwork, "--format", "{{.Name}}")
 			gomega.Expect(lines).Should(gomega.ConsistOf(bridgeNetwork, testNetwork))
 		})
 	})

--- a/tests/network_ls.go
+++ b/tests/network_ls.go
@@ -29,7 +29,7 @@ func NetworkLs(o *option.Option) {
 		})
 
 		ginkgo.It("should only display network name with --format flag", func() {
-			lines := command.StdOutAsLines(o, "network", "ls", "--format", "{{.Name}}")
+			lines := command.StdoutAsLines(o, "network", "ls", "--format", "{{.Name}}")
 			gomega.Expect(lines).Should(gomega.ContainElement(bridgeNetwork))
 		})
 

--- a/tests/network_rm.go
+++ b/tests/network_rm.go
@@ -24,16 +24,16 @@ func NetworkRm(o *option.Option) {
 		})
 
 		ginkgo.It("should remove a network", func() {
-			gomega.Expect(command.StdOutAsLines(o, "network", "ls", "--format", "{{.Name}}")).Should(gomega.ContainElement(testNetwork))
+			gomega.Expect(command.StdoutAsLines(o, "network", "ls", "--format", "{{.Name}}")).Should(gomega.ContainElement(testNetwork))
 			command.Run(o, "network", "rm", testNetwork)
-			gomega.Expect(command.StdOutAsLines(o, "network", "ls", "--format", "{{.Name}}")).ShouldNot(gomega.ContainElement(testNetwork))
+			gomega.Expect(command.StdoutAsLines(o, "network", "ls", "--format", "{{.Name}}")).ShouldNot(gomega.ContainElement(testNetwork))
 		})
 
 		ginkgo.It("should remove multiple networks", func() {
 			const testNetwork2 = "test-network2"
 			command.Run(o, "network", "create", testNetwork2)
 			command.Run(o, "network", "rm", testNetwork, testNetwork2)
-			lines := command.StdOutAsLines(o, "network", "ls", "--format", "{{.Name}}")
+			lines := command.StdoutAsLines(o, "network", "ls", "--format", "{{.Name}}")
 			gomega.Expect(lines).ShouldNot(gomega.ContainElement(testNetwork))
 			gomega.Expect(lines).ShouldNot(gomega.ContainElement(testNetwork2))
 		})

--- a/tests/run.go
+++ b/tests/run.go
@@ -57,7 +57,7 @@ func Run(o *RunOption) {
 			})
 
 			ginkgo.It("should not echo dummy output if running with -d flag", func() {
-				output := command.StdOut(o.BaseOpt, "run", "-d", testImageName)
+				output := command.Stdout(o.BaseOpt, "run", "-d", testImageName)
 				gomega.Expect(output).ShouldNot(gomega.ContainSubstring("finch-test-dummy-output"))
 			})
 		})
@@ -108,7 +108,7 @@ func Run(o *RunOption) {
 				}()
 				command.Run(o.BaseOpt, "build", "-q", "-t", testImageName, buildContext)
 
-				envOutput := command.StdOut(o.BaseOpt, "run", "--rm", "--entrypoint", "time", testImageName, "echo", "blah")
+				envOutput := command.Stdout(o.BaseOpt, "run", "--rm", "--entrypoint", "time", testImageName, "echo", "blah")
 				gomega.Expect(envOutput).NotTo(gomega.ContainSubstring("foo"))
 				gomega.Expect(envOutput).NotTo(gomega.ContainSubstring("bar"))
 				gomega.Expect(envOutput).To(gomega.ContainSubstring("blah"))
@@ -123,7 +123,7 @@ func Run(o *RunOption) {
 
 			for _, env := range []string{"-e", "--env"} {
 				ginkgo.It(fmt.Sprintf("with %s flag, environment variables should be set in the container", env), func() {
-					envOutput := command.StdOut(o.BaseOpt, "run", "--rm",
+					envOutput := command.Stdout(o.BaseOpt, "run", "--rm",
 						"--env", "FOO=BAR", "--env", "FOO1", "-e", "ENV1=1", "-e", "ENV1=2",
 						defaultImage, "env")
 					gomega.Expect(envOutput).To(gomega.ContainSubstring("FOO=BAR"))
@@ -137,7 +137,7 @@ func Run(o *RunOption) {
 				envPath := ffs.CreateTempFile("env", envPair)
 				ginkgo.DeferCleanup(os.RemoveAll, filepath.Dir(envPath))
 
-				envOutput := command.StdOut(o.BaseOpt, "run", "--rm", "--env-file", envPath, defaultImage, "env")
+				envOutput := command.Stdout(o.BaseOpt, "run", "--rm", "--env-file", envPath, defaultImage, "env")
 				gomega.Expect(envOutput).To(gomega.ContainSubstring(envPair))
 			})
 		})
@@ -261,13 +261,13 @@ func Run(o *RunOption) {
 
 			ginkgo.It("should be able to set custom DNS servers with --dns flag", func() {
 				const nameserver = "10.10.10.10"
-				lines := command.StdOutAsLines(o.BaseOpt, "run", "--dns", nameserver, "--name", testContainerName,
+				lines := command.StdoutAsLines(o.BaseOpt, "run", "--dns", nameserver, "--name", testContainerName,
 					defaultImage, "cat", "/etc/resolv.conf")
 				gomega.Expect(lines).Should(gomega.ContainElement(fmt.Sprintf("nameserver %s", nameserver)))
 			})
 
 			ginkgo.It("should be able to set custom DNS search domains with --dns-search flag", func() {
-				lines := command.StdOutAsLines(o.BaseOpt, "run", "--dns-search", "test", "--name", testContainerName,
+				lines := command.StdoutAsLines(o.BaseOpt, "run", "--dns-search", "test", "--name", testContainerName,
 					defaultImage, "cat", "/etc/resolv.conf")
 				gomega.Expect(lines).Should(gomega.ContainElement("search test"))
 			})
@@ -275,7 +275,7 @@ func Run(o *RunOption) {
 			for _, dnsOption := range []string{"--dns-opt", "--dns-option"} {
 				dnsOption := dnsOption
 				ginkgo.It(fmt.Sprintf("should be able to set DNS option with %s flag", dnsOption), func() {
-					lines := command.StdOutAsLines(o.BaseOpt, "run", dnsOption, "debug", "--name", testContainerName,
+					lines := command.StdoutAsLines(o.BaseOpt, "run", dnsOption, "debug", "--name", testContainerName,
 						defaultImage, "cat", "/etc/resolv.conf")
 					gomega.Expect(lines).Should(gomega.ContainElement("options debug"))
 				})

--- a/tests/tag.go
+++ b/tests/tag.go
@@ -24,8 +24,8 @@ func Tag(o *option.Option) {
 			pullImage(o, defaultImage)
 
 			command.Run(o, "tag", defaultImage, testImageName)
-			defaultImageID := command.StdOut(o, "images", "--quiet", "--no-trunc", defaultImage)
-			taggedImageID := command.StdOut(o, "images", "--quiet", "--no-trunc", testImageName)
+			defaultImageID := command.Stdout(o, "images", "--quiet", "--no-trunc", defaultImage)
+			taggedImageID := command.Stdout(o, "images", "--quiet", "--no-trunc", testImageName)
 			gomega.Expect(taggedImageID).ShouldNot(gomega.BeEmpty())
 			gomega.Expect(taggedImageID).To(gomega.Equal(defaultImageID))
 		})

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -97,59 +97,59 @@ func CleanupLocalRegistry(o *option.Option) {
 
 func pullImage(o *option.Option, imageName string) {
 	command.Run(o, "pull", "-q", imageName)
-	imageID := command.StdOut(o, "images", "--quiet", imageName)
+	imageID := command.Stdout(o, "images", "--quiet", imageName)
 	gomega.Expect(imageID).ShouldNot(gomega.BeEmpty())
 }
 
 func removeImage(o *option.Option, imageName string) {
 	command.Run(o, "rmi", "--force", imageName)
-	imageID := command.StdOut(o, "images", "--quiet", imageName)
+	imageID := command.Stdout(o, "images", "--quiet", imageName)
 	gomega.Expect(string(imageID)).Should(gomega.BeEmpty())
 }
 
 func containerShouldBeRunning(o *option.Option, containerNames ...string) {
 	for _, containerName := range containerNames {
-		gomega.Expect(command.StdOut(o, "ps", "-q", "--filter",
+		gomega.Expect(command.Stdout(o, "ps", "-q", "--filter",
 			fmt.Sprintf("name=%s", containerName))).NotTo(gomega.BeEmpty())
 	}
 }
 
 func containerShouldNotBeRunning(o *option.Option, containerNames ...string) {
 	for _, containerName := range containerNames {
-		gomega.Expect(command.StdOut(o, "ps", "-q", "--filter",
+		gomega.Expect(command.Stdout(o, "ps", "-q", "--filter",
 			fmt.Sprintf("name=%s", containerName))).To(gomega.BeEmpty())
 	}
 }
 
 func containerShouldExist(o *option.Option, containerNames ...string) {
 	for _, containerName := range containerNames {
-		gomega.Expect(command.StdOut(o, "ps", "-a", "-q", "--filter",
+		gomega.Expect(command.Stdout(o, "ps", "-a", "-q", "--filter",
 			fmt.Sprintf("name=%s", containerName))).NotTo(gomega.BeEmpty())
 	}
 }
 
 func containerShouldNotExist(o *option.Option, containerNames ...string) {
 	for _, containerName := range containerNames {
-		gomega.Expect(command.StdOut(o, "ps", "-a", "-q", "--filter",
+		gomega.Expect(command.Stdout(o, "ps", "-a", "-q", "--filter",
 			fmt.Sprintf("name=%s", containerName))).To(gomega.BeEmpty())
 	}
 }
 
 func imageShouldExist(o *option.Option, imageName string) {
-	gomega.Expect(command.StdOut(o, "images", "-q", imageName)).NotTo(gomega.BeEmpty())
+	gomega.Expect(command.Stdout(o, "images", "-q", imageName)).NotTo(gomega.BeEmpty())
 }
 
 func imageShouldNotExist(o *option.Option, imageName string) {
-	gomega.Expect(command.StdOut(o, "images", "-q", imageName)).To(gomega.BeEmpty())
+	gomega.Expect(command.Stdout(o, "images", "-q", imageName)).To(gomega.BeEmpty())
 }
 
 func volumeShouldExist(o *option.Option, volumeName string) {
-	gomega.Expect(command.StdOut(o, "volume", "ls", "-q", "--filter",
+	gomega.Expect(command.Stdout(o, "volume", "ls", "-q", "--filter",
 		fmt.Sprintf("name=%s", volumeName))).NotTo(gomega.BeEmpty())
 }
 
 func volumeShouldNotExist(o *option.Option, volumeName string) {
-	gomega.Expect(command.StdOut(o, "volume", "ls", "-q", "--filter",
+	gomega.Expect(command.Stdout(o, "volume", "ls", "-q", "--filter",
 		fmt.Sprintf("name=%s", volumeName))).To(gomega.BeEmpty())
 }
 

--- a/tests/volume_inspect.go
+++ b/tests/volume_inspect.go
@@ -33,7 +33,7 @@ func VolumeInspect(o *option.Option) {
 			const testVol2 = "testVol2"
 			command.Run(o, "volume", "create", testVolumeName)
 			command.Run(o, "volume", "create", testVol2)
-			lines := command.StdOutAsLines(o, "volume", "inspect", testVolumeName, "testVol2", "--format", "{{.Name}}")
+			lines := command.StdoutAsLines(o, "volume", "inspect", testVolumeName, "testVol2", "--format", "{{.Name}}")
 			gomega.Expect(lines).Should(gomega.ContainElements(testVolumeName, testVol2))
 		})
 

--- a/tests/volume_ls.go
+++ b/tests/volume_ls.go
@@ -27,7 +27,7 @@ func VolumeLs(o *option.Option) {
 			const testVol2 = "testVol2"
 			command.Run(o, "volume", "create", testVolumeName)
 			command.Run(o, "volume", "create", testVol2)
-			lines := command.StdOutAsLines(o, "volume", "ls", "--format", "{{.Name}}")
+			lines := command.StdoutAsLines(o, "volume", "ls", "--format", "{{.Name}}")
 			gomega.Expect(lines).Should(gomega.ContainElements(testVolumeName, testVol2))
 		})
 
@@ -35,7 +35,7 @@ func VolumeLs(o *option.Option) {
 			quiet := quiet
 			ginkgo.It(fmt.Sprintf("should only display volume names with %s flag", quiet), func() {
 				command.Run(o, "volume", "create", testVolumeName)
-				gomega.Expect(command.StdOutAsLines(o, "volume", "ls", quiet)).Should(gomega.ContainElement(testVolumeName))
+				gomega.Expect(command.StdoutAsLines(o, "volume", "ls", quiet)).Should(gomega.ContainElement(testVolumeName))
 			})
 		}
 	})

--- a/tests/volume_rm.go
+++ b/tests/volume_rm.go
@@ -36,7 +36,7 @@ func VolumeRm(o *option.Option) {
 			ginkgo.It("should remove multiple volumes", func() {
 				const testVol2 = "testVol2"
 				command.Run(o, "volume", "create", "testVol2")
-				gomega.Expect(command.StdOutAsLines(o, "volume", "ls", "--quiet")).Should(gomega.ContainElements(testVolumeName, testVol2))
+				gomega.Expect(command.StdoutAsLines(o, "volume", "ls", "--quiet")).Should(gomega.ContainElements(testVolumeName, testVol2))
 				command.Run(o, "volume", "rm", testVolumeName, testVol2)
 				volumeShouldNotExist(o, testVolumeName)
 			})


### PR DESCRIPTION
## Summary

PR renames `StdOut` and `StdErr` to `Stdout` and `Stderr` respectively to make them consistent with the naming in [std lib](https://pkg.go.dev/os#pkg-variables).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.