### PR TITLE
fix: Fix run -e/--env tests and add missing variable redefinition

### DIFF
--- a/tests/network_create.go
+++ b/tests/network_create.go
@@ -78,8 +78,9 @@ func NetworkCreate(o *option.Option) {
 		})
 
 		for _, driverFlag := range []string{"-d", "--driver"} {
+			driverFlag := driverFlag
 			for _, driver := range []string{"macvlan", "ipvlan"} {
-				driverFlag, driver := driverFlag, driver
+				driver := driver
 				ginkgo.It(fmt.Sprintf("should create %s network with %s flag", driver, driverFlag), func() {
 					command.Run(o, "network", "create", driverFlag, driver, testNetwork)
 					netType := command.StdoutStr(o, "network", "inspect", testNetwork, "--mode=native",

--- a/tests/network_create.go
+++ b/tests/network_create.go
@@ -78,8 +78,8 @@ func NetworkCreate(o *option.Option) {
 		})
 
 		for _, driverFlag := range []string{"-d", "--driver"} {
-			driverFlag := driverFlag
 			for _, driver := range []string{"macvlan", "ipvlan"} {
+				driverFlag, driver := driverFlag, driver
 				ginkgo.It(fmt.Sprintf("should create %s network with %s flag", driver, driverFlag), func() {
 					command.Run(o, "network", "create", driverFlag, driver, testNetwork)
 					netType := command.StdoutStr(o, "network", "inspect", testNetwork, "--mode=native",

--- a/tests/run.go
+++ b/tests/run.go
@@ -115,6 +115,7 @@ func Run(o *RunOption) {
 			})
 
 			for _, workDir := range []string{"--workdir", "-w"} {
+				workDir := workDir
 				ginkgo.It(fmt.Sprintf("should set working directory inside the container specified by %s flag", workDir), func() {
 					dir := "/tmp"
 					gomega.Expect(command.StdoutStr(o.BaseOpt, "run", workDir, dir, defaultImage, "pwd")).Should(gomega.Equal(dir))
@@ -122,9 +123,10 @@ func Run(o *RunOption) {
 			}
 
 			for _, env := range []string{"-e", "--env"} {
+				env := env
 				ginkgo.It(fmt.Sprintf("with %s flag, environment variables should be set in the container", env), func() {
 					envOutput := command.Stdout(o.BaseOpt, "run", "--rm",
-						"--env", "FOO=BAR", "--env", "FOO1", "-e", "ENV1=1", "-e", "ENV1=2",
+						env, "FOO=BAR", env, "FOO1", env, "ENV1=1", env, "ENV1=2",
 						defaultImage, "env")
 					gomega.Expect(envOutput).To(gomega.ContainSubstring("FOO=BAR"))
 					gomega.Expect(envOutput).ToNot(gomega.ContainSubstring("FOO1"))


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Currently `run -e/--env` tests don't use the env loop variable, instead they are hardcoded into the test string. We need to use the env loop variable.

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.