### PR TITLE
feat: add tests for special IP in --add-host flag

### DIFF
--- a/run/run_test.go
+++ b/run/run_test.go
@@ -38,13 +38,14 @@ func TestRun(t *testing.T) {
 	}, func() {})
 
 	const description = "Finch Shared E2E Tests"
+	const defaultHostGatewayIP = "192.168.5.2"
 	ginkgo.Describe(description, func() {
 		// Every test should be listed here.
 		// TODO: add tests for "system prune" and "network prune" after upgrading nerdctl to v0.23
 		tests.Pull(o)
 		tests.Rm(o)
 		tests.Rmi(o)
-		tests.Run(&tests.RunOption{BaseOpt: o, CGMode: tests.Unified})
+		tests.Run(&tests.RunOption{BaseOpt: o, CGMode: tests.Unified, DefaultHostGatewayIP: defaultHostGatewayIP})
 		tests.Start(o)
 		tests.Stop(o)
 		tests.Cp(o)

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -27,6 +27,7 @@ import (
 const (
 	alpineImage              = "public.ecr.aws/docker/library/alpine:latest"
 	olderAlpineImage         = "public.ecr.aws/docker/library/alpine:3.13"
+	amazonLinux2Image        = "public.ecr.aws/amazonlinux/amazonlinux:2"
 	testImageName            = "test:tag"
 	nonexistentImageName     = "ne-repo:ne-tag"
 	nonexistentContainerName = "ne-ctr"


### PR DESCRIPTION
Signed-off-by: Ziwen Ning <ningziwe@amazon.com>

Issue #, if available:
https://github.com/runfinch/finch/issues/209

*Description of changes:*
Start a server in host and try to curl it from container with `--add-host test-host:host-gateway`

*Testing done:*
`make run` with the change https://github.com/runfinch/finch/pull/216



- [ X ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.