### PR TITLE
fix: Fix tests to match nerdctl 1.2.1 outputs

### DIFF
--- a/tests/exec.go
+++ b/tests/exec.go
@@ -94,14 +94,15 @@ func Exec(o *option.Option) {
 			for _, user := range []string{"-u", "--user"} {
 				user := user
 				ginkgo.It(fmt.Sprintf("should output user id according to user name specified by %s flag", user), func() {
-					testCases := map[string]string{
-						"1000":       "uid=1000 gid=0(root)",
-						"1000:users": "uid=1000 gid=100(users)",
+					testCases := map[string][]string{
+						"1000":       {"uid=1000 gid=0(root)", "uid=1000 gid=0(root) groups=0(root)"},
+						"1000:users": {"uid=1000 gid=100(users)", "uid=1000 gid=100(users) groups=100(users)"},
 					}
 
 					for name, want := range testCases {
 						output := command.StdoutStr(o, "exec", user, name, testContainerName, "id")
-						gomega.Expect(output).Should(gomega.ContainSubstring(want))
+						// TODO: Remove the Or operator after upgrading the nerdctl dependency to 1.2.1 to only match want[1]
+						gomega.Expect(output).Should(gomega.Or(gomega.Equal(want[0]), gomega.Equal(want[1])))
 					}
 				})
 			}

--- a/tests/exec.go
+++ b/tests/exec.go
@@ -101,7 +101,7 @@ func Exec(o *option.Option) {
 
 					for name, want := range testCases {
 						output := command.StdoutStr(o, "exec", user, name, testContainerName, "id")
-						gomega.Expect(output).Should(gomega.Equal(want))
+						gomega.Expect(output).Should(gomega.ContainSubstring(want))
 					}
 				})
 			}

--- a/tests/images.go
+++ b/tests/images.go
@@ -52,7 +52,9 @@ func Images(o *option.Option) {
 		ginkgo.It("should list truncated IMAGE IDs", func() {
 			images := command.StdoutAsLines(o, "images", "--quiet")
 			gomega.Expect(images).ShouldNot(gomega.BeEmpty())
-			gomega.Expect(images).Should(gomega.HaveEach(gomega.MatchRegexp(sha256RegexTruncated)))
+			// TODO: Remove the Or operator after upgrading the nerdctl dependency to 1.2.1 to only match sha256RegexFull
+			gomega.Expect(images).To(gomega.Or(gomega.HaveEach(gomega.MatchRegexp(sha256RegexFull)),
+				gomega.HaveEach(gomega.MatchRegexp(sha256RegexTruncated))))
 		})
 		ginkgo.It("should list full IMAGE IDs", func() {
 			images := command.StdoutAsLines(o, "images", "--quiet", "--no-trunc")

--- a/tests/run.go
+++ b/tests/run.go
@@ -583,7 +583,7 @@ func Run(o *RunOption) {
 				}
 				for userStr, expected := range testCases {
 					output := command.StdoutStr(o.BaseOpt, "run", user, userStr, defaultImage, "id")
-					gomega.Expect(output).To(gomega.Equal(expected))
+					gomega.Expect(output).To(gomega.ContainSubstring(expected))
 				}
 			})
 
@@ -613,7 +613,7 @@ func Run(o *RunOption) {
 					}
 					args = append(args, defaultImage, "id")
 					output := command.StdoutStr(o.BaseOpt, args...)
-					gomega.Expect(output).To(gomega.Equal(tc.expected))
+					gomega.Expect(output).To(gomega.ContainSubstring(tc.expected))
 				}
 			})
 		}


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
After upgrading `nerdctl` dependency to 1.2.1, [7 e2e tests in finch fail](https://github.com/runfinch/finch/actions/runs/4421068149/jobs/7751480288#step:6:12894) due to failed assertions on output strings of finch commands. 

#### nerdctl images --quiet
Output before 1.2.1
```
$ nerdctl images --quiet
69665d02cb32
```
Output in 1.2.1
```
$ nerdctl images --quiet
sha256:ff6bdca1701f3a8a67e328815ff2346b0e4067d32ec36b7992c1fdc001dc8517
```

#### nerdctl run/exec -u/--user
Output before 1.2.1
```
$ nerdctl run -u nobody:100 alpine id                                   
uid=65534(nobody) gid=100(users)
```

Output in 1.2.1
```
$ nerdctl run -u nobody:100 alpine id
uid=65534(nobody) gid=100(users) groups=100(users)
```

#### nerdctl run --group-add
Output before 1.2.1
```
$ nerdctl run -u nobody --group-add 100 alpine id
uid=65534(nobody) gid=65534(nobody) groups=100(users)
```

Output in 1.2.1

```
$ nerdctl run -u nobody --group-add 100 alpine id
 uid=65534(nobody) gid=65534(nobody) groups=100(users),65534(nobody) 
```

*Testing done:*
Yes, locally. 

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.