### PR TITLE
test: fixing e2e test failure due to volume in use error

### DIFF
--- a/tests/compose_down.go
+++ b/tests/compose_down.go
@@ -6,10 +6,10 @@ package tests
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-
 	"github.com/runfinch/common-tests/command"
 	"github.com/runfinch/common-tests/ffs"
 	"github.com/runfinch/common-tests/option"
@@ -44,6 +44,11 @@ func ComposeDown(o *option.Option) {
 			volumes := volumes
 			ginkgo.It(fmt.Sprintf("should stop compose services and delete volumes by specifying %s flag", volumes), func() {
 				volumes := volumes
+				// Wait 10 sec before calling compose down since compose down cmd sometimes fails to delete the volume
+				// due to concurrent access of the volume.
+				// For more details - https://github.com/runfinch/finch/issues/261
+				time.Sleep(10 * time.Second)
+
 				command.Run(o, "compose", "down", volumes, "--file", composeFilePath)
 				containerShouldNotExist(o, containerNames...)
 				volumeShouldNotExist(o, "compose_data_volume")


### PR DESCRIPTION
Issue #, if available:
261
*Description of changes:*
Finch Container Development E2E Tests Compose down command fails to delete the volumes due to volume being used by compose up command. This PR added a delay of 10 sec after the compose up command to allow it to fully up and running the service. This additional wait will prevent the error of not being able to delete the volume by compose down command due to concurrent access.

The compose down command fails to delete the volumes because the compose up command is still using them. This PR adds a 10-second delay after the compose up command to avoid the error of not being able to delete the volume by the compose down command due to simultaneous access.

*Testing done:*
Yes


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.