### PR TITLE
ci: Update go linter version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
           # Pin the version in case all the builds start to fail at the same time.
           # There may not be an automatic way (e.g., dependabot) to update a specific parameter of a Github Action,
           # so we will just update it manually whenever it makes sense (e.g., a feature that we want is added).
-          version: v1.50.0
+          version: v1.51.2
           args: --fix=false


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Update version of `golangci-lint` to keep it consistent with [finch](https://github.com/runfinch/finch/blob/main/.github/workflows/ci.yaml#L59).

*Testing done:*



- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.