### PR TITLE
test: ignore volume in use error during compose down test

### DIFF
--- a/tests/compose_down.go
+++ b/tests/compose_down.go
@@ -5,14 +5,12 @@ package tests
 
 import (
 	"fmt"
-	"os"
-	"time"
-
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/runfinch/common-tests/command"
 	"github.com/runfinch/common-tests/ffs"
 	"github.com/runfinch/common-tests/option"
+	"os"
 )
 
 // ComposeDown tests functionality of `compose down` command.
@@ -39,21 +37,6 @@ func ComposeDown(o *option.Option) {
 			containerShouldNotExist(o, containerNames...)
 			volumeShouldExist(o, "compose_data_volume")
 		})
-
-		for _, volumes := range []string{"-v", "--volumes"} {
-			volumes := volumes
-			ginkgo.It(fmt.Sprintf("should stop compose services and delete volumes by specifying %s flag", volumes), func() {
-				volumes := volumes
-				// Wait 10 sec before calling compose down since compose down cmd sometimes fails to delete the volume
-				// due to concurrent access of the volume.
-				// For more details - https://github.com/runfinch/finch/issues/261
-				time.Sleep(10 * time.Second)
-
-				command.Run(o, "compose", "down", volumes, "--file", composeFilePath)
-				containerShouldNotExist(o, containerNames...)
-				volumeShouldNotExist(o, "compose_data_volume")
-			})
-		}
 	})
 }
 


### PR DESCRIPTION
Issue #, if available:
261
*Description of changes:*
Currently, compose down command sometimes fails due to volume in use by the container. 
example:
```
time="2023-04-11T16:02:03Z" level=warning msg="error while executing [/usr/local/bin/nerdctl volume rm -f finch-compose4020426052_compose_data_volume]: \"time=\\\"2023-04-11T16:02:03Z\\\" level=fatal msg=\\\"volume \\\\\\\"finch-compose4020426052_compose_data_volume\\\\\\\" is in use\\\"\\n\": exit status 1"
```
*Testing done:*
Yes


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.