### PR TITLE
feat: verify the result of finch inspect has State.Status and State.Error

### DIFF
--- a/tests/inspect.go
+++ b/tests/inspect.go
@@ -27,6 +27,8 @@ func Inspect(o *option.Option) {
 			gomega.Expect(image).To(gomega.Equal(defaultImage))
 			containerName := command.StdoutStr(o, "inspect", "--format", "{{.Name}}", testContainerName)
 			gomega.Expect(containerName).To(gomega.Equal(testContainerName))
+			gomega.Expect(command.StdoutStr(o, "inspect", "--format", "{{.State.Status}}", testContainerName)).To(gomega.Equal("exited"))
+			gomega.Expect(command.StdoutStr(o, "inspect", "--format", "{{.State.Error}}", testContainerName)).To(gomega.Equal(""))
 		})
 
 		ginkgo.It("should display multiple container image with --format flag", func() {


### PR DESCRIPTION
verify the result of finch inspect has State.Status and State.Error

https://github.com/runfinch/finch/issues/242

*Description of changes:*
Test for the scenario of the issue

*Testing done:*
Tested locally.


- [ X ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.