### PR TITLE
fix: make tests compatible with nerdctlv1.5

### DIFF
--- a/tests/compose_build.go
+++ b/tests/compose_build.go
@@ -19,7 +19,7 @@ import (
 // ComposeBuild tests functionality of `compose build` command.
 func ComposeBuild(o *option.Option) {
 	services := []string{"svc1_build_cmd", "svc2_build_cmd"}
-	imageSuffix := []string{"alpine:latest", "_svc2_build_cmd:latest"}
+	imageSuffix := []string{"alpine:latest", "-svc2_build_cmd:latest"}
 	ginkgo.Describe("Compose build command", func() {
 		var composeContext string
 		var composeFilePath string

--- a/tests/run.go
+++ b/tests/run.go
@@ -16,7 +16,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"github.com/runfinch/common-tests/fenv"
 
 	"github.com/runfinch/common-tests/command"
 	"github.com/runfinch/common-tests/ffs"
@@ -448,54 +447,12 @@ func Run(o *RunOption) {
 				verifyMountsInfo(actualMount, expectedMount)
 			})
 
-			// TODO: Remove FINCH_DOCKER_COMPAT=1 check when FINCH_DOCKER_COMPAT flag is removed in finch
-			ginkgo.It("should create nested bind mounts within a container when FINCH_DOCKER_COMPAT is not set", func() {
+			ginkgo.It("should create nested bind mounts within a container", func() {
 				const (
 					outerDir  = "/outer"
 					nestedDir = "/outer/nested"
 				)
 
-				if fenv.GetEnv("FINCH_DOCKER_COMPAT") == "1" {
-					ginkgo.Skip("Skipping test: FINCH_DOCKER_COMPAT is set to 1")
-				}
-				// Create the nested directory on the host
-				hostDirectory := ffs.CreateNestedDir(outerDir)
-				nestedDirectory := ffs.CreateNestedDir(nestedDir)
-				defer ffs.DeleteDirectory(hostDirectory)
-
-				// Directory on host to be mounted at hostDirectory in container
-				tempDir := ffs.CreateTempDir("some_dir")
-				defer ffs.DeleteDirectory(tempDir)
-				// Write a file to the nested directory
-				nestedFilePath := filepath.Join(nestedDirectory, "file1.txt")
-				ffs.WriteFile(nestedFilePath, "test")
-
-				// Mount nested directory first followed by parent directory
-				// Upstream issue: https://github.com/containerd/nerdctl/issues/2254
-				command.RunWithoutSuccessfulExit(o.BaseOpt, "run", "--rm", "--name", testContainerName,
-					"-v", nestedDirectory+":"+nestedDirectory,
-					"-v", tempDir+":"+hostDirectory,
-					defaultImage, "sh", "-c", "ls "+nestedDirectory)
-
-				// Mount parent directory first followed by nested
-				output := command.StdoutStr(o.BaseOpt, "run", "--rm", "--name", testContainerName2,
-					"-v", tempDir+":"+hostDirectory,
-					"-v", nestedDirectory+":"+nestedDirectory,
-					defaultImage, "sh", "-c", "ls "+nestedDirectory)
-				gomega.Expect(output).Should(gomega.ContainSubstring("file1.txt"))
-			})
-
-			// TODO: Remove FINCH_DOCKER_COMPAT=1 check when FINCH_DOCKER_COMPAT flag is removed in finch
-			// https://github.com/runfinch/finch/pull/417/files
-
-			ginkgo.It("should create nested bind mounts within a container when FINCH_DOCKER_COMPAT is set", func() {
-				const (
-					outerDir  = "/outer"
-					nestedDir = "/outer/nested"
-				)
-				if fenv.GetEnv("FINCH_DOCKER_COMPAT") != "1" {
-					ginkgo.Skip("Skipping test: FINCH_DOCKER_COMPAT is not set to 1")
-				}
 				// Create the nested directory on the host
 				hostDirectory := ffs.CreateNestedDir(outerDir)
 				nestedDirectory := ffs.CreateNestedDir(nestedDir)


### PR DESCRIPTION
*Description of changes:*

nerdctl released v1.5 and we saw some test regressions in runfinch/finch#521:

* compose container suffix changed
* cp now works with stopped containers
* nested bind mounts issue resolved

Follow up PR after in finch to remove `FINCH_DOCKER_COMPAT` env variable: https://github.com/runfinch/finch/issues/418

Issue #, if available:



*Testing done:*

pulled down runfinch/finch#521 locally, `replace` directive to point to local common-tests, `make test-e2e-container`

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.