### PR TITLE
fix: Fix container filepath to make it platform independent

### DIFF
--- a/tests/cp.go
+++ b/tests/cp.go
@@ -20,7 +20,7 @@ import (
 func Cp(o *option.Option) {
 	filename := "test-file"
 	content := "test-content"
-	containerFilepath := filepath.Join("/tmp", filename)
+	containerFilepath := filepath.ToSlash(filepath.Join("/tmp", filename))
 	containerResource := fmt.Sprintf("%s:%s", testContainerName, containerFilepath)
 
 	ginkgo.Describe("copy from container to host and vice versa", func() {


### PR DESCRIPTION
Issue #, if available:
N/A
*Description of changes:*
In the `container cp` command test, container path is evaluated using `filepath.Join("/tmp", filename)`. On windows this evaluates to `/tmp\<filename>` which is not a unix path for the container. 

*Testing done:*
Yes


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.