### PR TITLE
fix: increase acceptable time deviation for stop tests with -t

### DIFF
--- a/tests/stop.go
+++ b/tests/stop.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-
 	"github.com/runfinch/common-tests/command"
 	"github.com/runfinch/common-tests/option"
 )
@@ -41,7 +40,7 @@ func Stop(o *option.Option) {
 				gomega.Expect(command.StdoutStr(o, "exec", testContainerName, "echo", "foo")).To(gomega.Equal("foo"))
 				startTime := time.Now()
 				command.Run(o, "stop", "-t", "1", testContainerName)
-				gomega.Expect(time.Since(startTime)).To(gomega.BeNumerically("~", 1*time.Second, 500*time.Millisecond))
+				gomega.Expect(time.Since(startTime)).To(gomega.BeNumerically("~", 1*time.Second, 750*time.Millisecond))
 				command.RunWithoutSuccessfulExit(o, "exec", testContainerName, "echo", "foo")
 			})
 		}


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*

Increase acceptable time deviation from 500ms -> 750ms.

This test checks to see that the `-t/--time` flag waits a certain amount of time (in the test's case, 1s) before sending the stop signal and killing the container. We're currently seeing fairly frequent failures of this test in `finch-core`, with stop times very slightly outside of the acceptable range:

- [1.529945577s](https://github.com/runfinch/finch-core/actions/runs/6228992440/job/16933345175?pr=159#step:7:13397)
- [1.528963170s](https://github.com/runfinch/finch-core/actions/runs/6228992440/job/16933345175?pr=159#step:7:13397)
- [1.502652516s](https://github.com/runfinch/finch-core/actions/runs/6228992440/job/16933345175?pr=159#step:7:13314)
- etc...

This exact timing isn't super critical, and these test failures are kind of painful for merging PRs, so increasing the allowable deviation makes sense here.

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.