### PR TITLE
fix: Update logs test args

### DIFF
--- a/tests/logs.go
+++ b/tests/logs.go
@@ -54,7 +54,7 @@ func Logs(o *option.Option) {
 				time.Sleep(2 * time.Second)
 				output := command.StdoutStr(o, "logs", "--since", "1s", testContainerName)
 				gomega.Expect(output).Should(gomega.BeEmpty())
-				output = command.StdoutStr(o, "logs", "--since", "3s", testContainerName)
+				output = command.StdoutStr(o, "logs", "--since", "5s", testContainerName)
 				gomega.Expect(output).Should(gomega.Equal(foo))
 			})
 
@@ -62,7 +62,7 @@ func Logs(o *option.Option) {
 				time.Sleep(2 * time.Second)
 				output := command.StdoutStr(o, "logs", "--until", "1s", testContainerName)
 				gomega.Expect(output).Should(gomega.Equal(foo))
-				output = command.StdoutStr(o, "logs", "--until", "3s", testContainerName)
+				output = command.StdoutStr(o, "logs", "--until", "5s", testContainerName)
 				gomega.Expect(output).Should(gomega.BeEmpty())
 			})
 		})


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Changing values for `--since` and `--until` based on windows e2e testing. For `--since` change from 3s=>5s(for logs to show up) to show logs from [current time - 5s](i.e the container run falls within this window). For `--until`, change from 3s=>5s(for logs not to show up), i.e container start time does not happen between [0 - (current time -5s)]
*Testing done:*
Yes


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.