### PR TITLE
fix: adds --all to the volume prune command to prune named volumes

### DIFF
--- a/command/remove.go
+++ b/command/remove.go
@@ -5,7 +5,6 @@ package command
 
 import (
 	"github.com/onsi/ginkgo/v2"
-
 	"github.com/runfinch/common-tests/option"
 )
 
@@ -42,7 +41,7 @@ func RemoveVolumes(o *option.Option) {
 		ginkgo.GinkgoWriter.Println("No volumes to be removed")
 		return
 	}
-	Run(o, "volume", "prune", "--force")
+	Run(o, "volume", "prune", "--force", "--all")
 }
 
 // RemoveImages removes all container images in the testing environment specified by o.


### PR DESCRIPTION
see https://github.com/containerd/nerdctl/commit/0844a51e43df1c7c445c3142e7729069c06812bd

Issue #, if available:

*Description of changes:*

CI was failing in finch and finch-core due to a named volume not getting cleaned up after bumping nerdctl to v1.6.0. turns out there was a change in behavior for the `volume prune` command.

*Testing done:*

Ran common-tests with @vsiravar and the volume tests succeeded

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.