### PR TITLE
fix: disable build --ssh test on Windows

### DIFF
--- a/tests/build.go
+++ b/tests/build.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
@@ -127,6 +128,9 @@ func Build(o *option.Option) {
 			})
 
 			ginkgo.It("Build an image with --ssh option", func() {
+				if runtime.GOOS == "windows" {
+					ginkgo.Skip("non-functional on Windows, see https://github.com/runfinch/finch/issues/750")
+				}
 				containerWithSSH := fmt.Sprintf(`FROM %s
 				RUN ["echo", "built from Dockerfile.with-ssh"]
 			`, defaultImage)


### PR DESCRIPTION
Issue #, if available: https://github.com/runfinch/finch/issues/750, https://github.com/runfinch/finch/pull/649/#issuecomment-1879168058

*Description of changes:*
- Disable build --ssh test when running on Windows

*Testing done:*
- Ran test suite on Windows machine, and it skipped as expected
```
  [SKIPPED] non-functional on Windows, see https://github.com/runfinch/finch/issues/750
  In [It] at: C:/Users/Administrator/Code/common-tests/tests/build.go:131 @ 01/05/24 20:18:38.223
------------------------------
[SynchronizedAfterSuite]
C:/Users/Administrator/Code/common-tests/run/run_test.go:36
  ef5e5b2ec9fd42f39e6c3a3daac04488b0d7c434446b18eaf4c7c7b6e9cc4ea0
  ef5e5b2ec9fd42f39e6c3a3daac04488b0d7c434446b18eaf4c7c7b6e9cc4ea0
  0a182cb82c93
  Untagged: public.ecr.aws/docker/library/registry:latest@sha256:0a182cb82c93939407967d6d71d6caf11dcef0e5689c6afe2d60518e3b34ab86
  Deleted: sha256:9fe9a137fd002363ac64f5af66146702432b638a83ee0c5b620c40a9e433e813
  Deleted: sha256:d9bce47b357e434a4b294543f1f58cf3113de1d5356dfcb0c67fad2af92f8633
  Deleted: sha256:afcdb1715fb302c8cefa6e90a55c096e13a8d49faee6daaf7745dc0f95f9e90d
  Deleted: sha256:9f383ae4f64d95caaff5c106cf502c1a6f65617a4de01f2cad10353c0e825f5c
  Deleted: sha256:645ddea727356ff8ceb7f90d5ac0aee83bff1ac1ddae1f964228c3051ea50f50
[SynchronizedAfterSuite] PASSED [3.579 seconds]
------------------------------

Ran 0 of 1 Specs in 25.101 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 1 Skipped
```

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.