### PR TITLE
fix: fix panic in HTTPGetAndAssert

### DIFF
--- a/fnet/dial.go
+++ b/fnet/dial.go
@@ -13,14 +13,17 @@ import (
 
 // HTTPGetAndAssert sends an HTTP GET request to the specified URL, asserts the response status code against want, and closes the response body.
 func HTTPGetAndAssert(url string, want int, maxRetry int, retryInterval time.Duration) {
-	var err error
+	var (
+		err  error
+		resp *http.Response
+	)
 	client := http.Client{
 		Timeout: 5 * time.Second,
 	}
 
 	for i := 0; i < maxRetry; i++ {
 		// #nosec G107 // it does not matter if url is not a constant for testing.
-		resp, err := client.Get(url)
+		resp, err = client.Get(url)
 		if err != nil {
 			time.Sleep(retryInterval)
 			continue


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
fix panic in fnet. When HTTP err != nil the test panics due to `err` shadowing the `err` declared outside the for loop. 
*Testing done:*
Yes. 


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.