### PR TITLE
fix: allow propagation time for async conditions

### DIFF
--- a/tests/events.go
+++ b/tests/events.go
@@ -4,6 +4,8 @@
 package tests
 
 import (
+	"time"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
@@ -26,7 +28,11 @@ func Events(o *option.Option) {
 			defer session.Kill()
 			gomega.Expect(session.Out.Contents()).Should(gomega.BeEmpty())
 			command.Run(o, "pull", defaultImage)
-			gomega.Expect(session.Out.Contents()).Should(gomega.ContainSubstring(defaultImage))
+			// allow propagation time
+			gomega.Eventually(session.Out.Contents()).
+				WithTimeout(15 * time.Second).
+				WithPolling(1 * time.Second).
+				Should(gomega.ContainSubstring(defaultImage))
 		})
 	})
 }

--- a/tests/logs.go
+++ b/tests/logs.go
@@ -99,9 +99,8 @@ func Logs(o *option.Option) {
 					defer session.Kill()
 					gomega.Expect(session.Out.Contents()).Should(gomega.BeEmpty())
 					command.Run(o, "exec", testContainerName, "sh", "-c", fmt.Sprintf("echo %s >> /proc/1/fd/1", newLog))
-					output := strings.TrimSpace(string(session.Out.Contents()))
 					// allow propagation time
-					gomega.Eventually(output).
+					gomega.Eventually(strings.TrimSpace(string(session.Out.Contents()))).
 						WithTimeout(15 * time.Second).
 						WithPolling(1 * time.Second).
 						Should(gomega.Equal(newLog))

--- a/tests/logs.go
+++ b/tests/logs.go
@@ -100,7 +100,11 @@ func Logs(o *option.Option) {
 					gomega.Expect(session.Out.Contents()).Should(gomega.BeEmpty())
 					command.Run(o, "exec", testContainerName, "sh", "-c", fmt.Sprintf("echo %s >> /proc/1/fd/1", newLog))
 					output := strings.TrimSpace(string(session.Out.Contents()))
-					gomega.Expect(output).Should(gomega.Equal(newLog))
+					// allow propagation time
+					gomega.Eventually(output).
+						WithTimeout(15 * time.Second).
+						WithPolling(1 * time.Second).
+						Should(gomega.Equal(newLog))
 				})
 			}
 		})


### PR DESCRIPTION
Issue #, if available: Seen several tests fail (especially on Windows) because of these types of checks. See: https://github.com/runfinch/finch/actions/runs/7493150724/job/20398226027 and https://github.com/runfinch/finch/actions/runs/7493200344/job/20398390738

*Description of changes:*
- Adds a timeout and polling to these checks. This should have no impact when the condition is achieved quickly, but allow it to take up to 15 seconds at the worst case

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.