### PR TITLE
fix: increase nginx pull timeout

### DIFF
--- a/tests/run.go
+++ b/tests/run.go
@@ -366,7 +366,10 @@ func Run(o *RunOption) {
 					hostPort := fnet.GetFreePort()
 					// Start an Nginx container in detached mode with the specified publish flag and mapping the container port to
 					// a randomly selected host port.
-					command.Run(o.BaseOpt, "run", "-d", publish, fmt.Sprintf("%d:%d", hostPort, containerPort), nginxImage)
+					command.
+						New(o.BaseOpt, "run", "-d", publish, fmt.Sprintf("%d:%d", hostPort, containerPort), nginxImage).
+						WithTimeoutInSeconds(20).
+						Run()
 					fnet.HTTPGetAndAssert(fmt.Sprintf("http://localhost:%d", hostPort), 200, 20, 200*time.Millisecond)
 				})
 			}


### PR DESCRIPTION
Issue #, if available: Seems like sometimes the nginx pull fails, see https://github.com/runfinch/finch/actions/runs/7506223106/job/20437155927?pr=759

*Description of changes:*
- Increase timeout

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.