### PR TITLE
fix: increase event timeout

### DIFF
--- a/tests/logs.go
+++ b/tests/logs.go
@@ -101,7 +101,7 @@ func Logs(o *option.Option) {
 					command.Run(o, "exec", testContainerName, "sh", "-c", fmt.Sprintf("echo %s >> /proc/1/fd/1", newLog))
 					// allow propagation time
 					gomega.Eventually(strings.TrimSpace(string(session.Out.Contents()))).
-						WithTimeout(15 * time.Second).
+						WithTimeout(30 * time.Second).
 						WithPolling(1 * time.Second).
 						Should(gomega.Equal(newLog))
 				})


### PR DESCRIPTION
Issue #, if available: Still seeing failures: https://github.com/runfinch/finch/actions/runs/7820846068/job/21371714848?pr=795#step:10:6233

*Description of changes:*
- Double event timeout

*Testing done:*
- The same tests currently runs twice, with different arguments. Sometimes, one of these times succeeds in just under 15 seconds, so increasing the timeout to over 15s may make the test more reliable
    - https://github.com/runfinch/finch/actions/runs/7820846068/job/21371714848?pr=795#step:10:6184



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.