### PR TITLE
fix: use new values of session

### DIFF
--- a/tests/events.go
+++ b/tests/events.go
@@ -4,10 +4,12 @@
 package tests
 
 import (
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
 
 	"github.com/runfinch/common-tests/command"
 	"github.com/runfinch/common-tests/option"
@@ -29,7 +31,9 @@ func Events(o *option.Option) {
 			gomega.Expect(session.Out.Contents()).Should(gomega.BeEmpty())
 			command.Run(o, "pull", defaultImage)
 			// allow propagation time
-			gomega.Eventually(session.Out.Contents()).
+			gomega.Eventually(func(session *gexec.Session) string {
+				return strings.TrimSpace(string(session.Out.Contents()))
+			}).WithArguments(session).
 				WithTimeout(15 * time.Second).
 				WithPolling(1 * time.Second).
 				Should(gomega.ContainSubstring(defaultImage))

--- a/tests/logs.go
+++ b/tests/logs.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
 
 	"github.com/runfinch/common-tests/command"
 	"github.com/runfinch/common-tests/option"
@@ -100,7 +101,9 @@ func Logs(o *option.Option) {
 					gomega.Expect(session.Out.Contents()).Should(gomega.BeEmpty())
 					command.Run(o, "exec", testContainerName, "sh", "-c", fmt.Sprintf("echo %s >> /proc/1/fd/1", newLog))
 					// allow propagation time
-					gomega.Eventually(strings.TrimSpace(string(session.Out.Contents()))).
+					gomega.Eventually(func(session *gexec.Session) string {
+						return strings.TrimSpace(string(session.Out.Contents()))
+					}).WithArguments(session).
 						WithTimeout(30 * time.Second).
 						WithPolling(1 * time.Second).
 						Should(gomega.Equal(newLog))


### PR DESCRIPTION
Issue #, if available: https://github.com/runfinch/finch/actions/runs/8028176583/job/22044404059?pr=830

*Description of changes:*

Previously, the polling solution would just re-poll with the same string it got from the initial `session.Out.Contents()`, so polling was not really doing anything.

Now, every time it polls, a new value is used.

*Testing done:*
- Tested locally


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.