### PR TITLE
fix: Add a wait for server to start before doing a curl, to avoid sync issue

### DIFF
--- a/tests/run.go
+++ b/tests/run.go
@@ -342,6 +342,8 @@ func Run(o *RunOption) {
 				hostPort := fnet.GetFreePort()
 				s := http.Server{Addr: fmt.Sprintf(":%d", hostPort), Handler: mux, ReadTimeout: 30 * time.Second}
 				go s.ListenAndServe() //nolint:errcheck // Asynchronously starting server for testing only.
+
+				time.Sleep(5 * time.Second)
 				ginkgo.DeferCleanup(s.Shutdown, ctx)
 				command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, "--add-host", "test-host:host-gateway",
 					amazonLinux2Image, "sleep", "infinity")


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*

*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.