### PR TITLE
perf: pre-fetch all images before running tests

### DIFF
--- a/command/remove.go
+++ b/command/remove.go
@@ -18,9 +18,9 @@ func RemoveAll(o *option.Option) {
 
 // RemoveContainers removes all containers in the testing environment specified by o.
 func RemoveContainers(o *option.Option) {
-	allIds := GetAllContainerIDs(o)
+	allIDs := GetAllContainerIDs(o)
 	var ids []string
-	for _, id := range allIds {
+	for _, id := range allIDs {
 		if id != localRegistryContainerID {
 			ids = append(ids, id)
 		}
@@ -46,9 +46,9 @@ func RemoveVolumes(o *option.Option) {
 
 // RemoveImages removes all container images in the testing environment specified by o.
 func RemoveImages(o *option.Option) {
-	allIds := GetAllImageIDs(o)
+	allIDs := GetAllImageIDs(o)
 	var ids []string
-	for _, id := range allIds {
+	for _, id := range allIDs {
 		if id != localRegistryImageID {
 			ids = append(ids, id)
 		}

--- a/run/run_test.go
+++ b/run/run_test.go
@@ -31,7 +31,7 @@ func TestRun(t *testing.T) {
 	ginkgo.SynchronizedBeforeSuite(func() []byte {
 		tests.SetupLocalRegistry(o)
 		return nil
-	}, func(bytes []byte) {})
+	}, func(_ []byte) {})
 
 	ginkgo.SynchronizedAfterSuite(func() {
 		tests.CleanupLocalRegistry(o)

--- a/tests/build.go
+++ b/tests/build.go
@@ -30,7 +30,7 @@ func Build(o *option.Option) {
 			ginkgo.BeforeEach(func() {
 				buildContext = ffs.CreateBuildContext(fmt.Sprintf(`FROM %s
 			CMD ["echo", "finch-test-dummy-output"]
-			`, defaultImage))
+			`, localImages["defaultImage"]))
 				ginkgo.DeferCleanup(os.RemoveAll, buildContext)
 				command.RemoveAll(o)
 			})
@@ -53,7 +53,7 @@ func Build(o *option.Option) {
 					dockerFilePath = filepath.Join(buildContext, "AnotherDockerfile")
 					ffs.WriteFile(dockerFilePath, fmt.Sprintf(`FROM %s
 			RUN ["echo", "built from AnotherDockerfile"]
-			`, defaultImage))
+			`, localImages["defaultImage"]))
 				})
 
 				for _, file := range []string{"-f", "--file"} {
@@ -68,7 +68,7 @@ func Build(o *option.Option) {
 			ginkgo.It("build image with --secret option", func() {
 				containerWithSecret := fmt.Sprintf(`FROM %s
 			RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret
-			`, defaultImage)
+			`, localImages["defaultImage"])
 				dockerFilePath := filepath.Join(buildContext, "Dockerfile.with-secret")
 				ffs.WriteFile(dockerFilePath, containerWithSecret)
 				secretFile := filepath.Join(buildContext, "secret.txt")
@@ -83,7 +83,7 @@ func Build(o *option.Option) {
 			RUN echo output from build_env
 			FROM %s AS prod_env
 			RUN  echo "output from prod_env
-			`, defaultImage, defaultImage)
+			`, localImages["defaultImage"], localImages["defaultImage"])
 				dockerFilePath := filepath.Join(buildContext, "Dockerfile.with-target")
 				ffs.WriteFile(dockerFilePath, containerWithTarget)
 				stdEr := command.Stderr(o, "build", "--progress=plain", "--no-cache",
@@ -110,7 +110,7 @@ func Build(o *option.Option) {
 			ginkgo.It("build image with --progress=plain", func() {
 				dockerFile := fmt.Sprintf(`FROM %s
 				RUN echo "progress flag set:$((1 + 1))"
-			`, defaultImage)
+			`, localImages["defaultImage"])
 				dockerFilePath := filepath.Join(buildContext, "Dockerfile.progress")
 				ffs.WriteFile(dockerFilePath, dockerFile)
 				stdErr := command.Stderr(o, "build", "-f", dockerFilePath, "--no-cache", "--progress=plain", buildContext)
@@ -133,7 +133,7 @@ func Build(o *option.Option) {
 				}
 				containerWithSSH := fmt.Sprintf(`FROM %s
 				RUN ["echo", "built from Dockerfile.with-ssh"]
-			`, defaultImage)
+			`, localImages["defaultImage"])
 				dockerFilePath := filepath.Join(buildContext, "Dockerfile.with-ssh")
 				ffs.WriteFile(dockerFilePath, containerWithSSH)
 				stdErr := command.Stderr(o, "build", "--ssh", "default", "-f", dockerFilePath, buildContext)
@@ -158,7 +158,7 @@ func Build(o *option.Option) {
 						fileName: "Dockerfile.NoEnv",
 						instructions: fmt.Sprintf(`FROM %s
 				ENV PATH
-				`, defaultImage),
+				`, localImages["defaultImage"]),
 						errorMessage: "ENV must have two arguments",
 					},
 					{
@@ -195,10 +195,10 @@ func Build(o *option.Option) {
 				command.RemoveAll(o)
 			})
 			// If SetupLocalRegistry is invoked before this test case,
-			// then defaultImage will point to the image in the local registry,
+			// then localImages["defaultImage"] will point to the image in the local registry,
 			// and there will be only one platform (i.e., the platform of the running machine) available for that image in the local registry.
 			// As a result, to make this test case not flaky even when SetupLocalRegistry is used,
-			// we need to pull alpineImage instead of defaultImage
+			// we need to pull alpineImage instead of localImages["defaultImage"]
 			// because we can be sure that the registry associated with the former provides the image with the platform specified below.
 			ginkgo.It("build basic alpine image with --platform option", func() {
 				command.Run(o, "build", "-t", testImageName, "--platform=amd64", buildContext)

--- a/tests/build.go
+++ b/tests/build.go
@@ -30,7 +30,7 @@ func Build(o *option.Option) {
 			ginkgo.BeforeEach(func() {
 				buildContext = ffs.CreateBuildContext(fmt.Sprintf(`FROM %s
 			CMD ["echo", "finch-test-dummy-output"]
-			`, localImages["defaultImage"]))
+			`, localImages[defaultImage]))
 				ginkgo.DeferCleanup(os.RemoveAll, buildContext)
 				command.RemoveAll(o)
 			})
@@ -53,7 +53,7 @@ func Build(o *option.Option) {
 					dockerFilePath = filepath.Join(buildContext, "AnotherDockerfile")
 					ffs.WriteFile(dockerFilePath, fmt.Sprintf(`FROM %s
 			RUN ["echo", "built from AnotherDockerfile"]
-			`, localImages["defaultImage"]))
+			`, localImages[defaultImage]))
 				})
 
 				for _, file := range []string{"-f", "--file"} {
@@ -68,7 +68,7 @@ func Build(o *option.Option) {
 			ginkgo.It("build image with --secret option", func() {
 				containerWithSecret := fmt.Sprintf(`FROM %s
 			RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret
-			`, localImages["defaultImage"])
+			`, localImages[defaultImage])
 				dockerFilePath := filepath.Join(buildContext, "Dockerfile.with-secret")
 				ffs.WriteFile(dockerFilePath, containerWithSecret)
 				secretFile := filepath.Join(buildContext, "secret.txt")
@@ -83,7 +83,7 @@ func Build(o *option.Option) {
 			RUN echo output from build_env
 			FROM %s AS prod_env
 			RUN  echo "output from prod_env
-			`, localImages["defaultImage"], localImages["defaultImage"])
+			`, localImages[defaultImage], localImages[defaultImage])
 				dockerFilePath := filepath.Join(buildContext, "Dockerfile.with-target")
 				ffs.WriteFile(dockerFilePath, containerWithTarget)
 				stdEr := command.Stderr(o, "build", "--progress=plain", "--no-cache",
@@ -110,7 +110,7 @@ func Build(o *option.Option) {
 			ginkgo.It("build image with --progress=plain", func() {
 				dockerFile := fmt.Sprintf(`FROM %s
 				RUN echo "progress flag set:$((1 + 1))"
-			`, localImages["defaultImage"])
+			`, localImages[defaultImage])
 				dockerFilePath := filepath.Join(buildContext, "Dockerfile.progress")
 				ffs.WriteFile(dockerFilePath, dockerFile)
 				stdErr := command.Stderr(o, "build", "-f", dockerFilePath, "--no-cache", "--progress=plain", buildContext)
@@ -133,7 +133,7 @@ func Build(o *option.Option) {
 				}
 				containerWithSSH := fmt.Sprintf(`FROM %s
 				RUN ["echo", "built from Dockerfile.with-ssh"]
-			`, localImages["defaultImage"])
+			`, localImages[defaultImage])
 				dockerFilePath := filepath.Join(buildContext, "Dockerfile.with-ssh")
 				ffs.WriteFile(dockerFilePath, containerWithSSH)
 				stdErr := command.Stderr(o, "build", "--ssh", "default", "-f", dockerFilePath, buildContext)
@@ -158,7 +158,7 @@ func Build(o *option.Option) {
 						fileName: "Dockerfile.NoEnv",
 						instructions: fmt.Sprintf(`FROM %s
 				ENV PATH
-				`, localImages["defaultImage"]),
+				`, localImages[defaultImage]),
 						errorMessage: "ENV must have two arguments",
 					},
 					{
@@ -195,10 +195,10 @@ func Build(o *option.Option) {
 				command.RemoveAll(o)
 			})
 			// If SetupLocalRegistry is invoked before this test case,
-			// then localImages["defaultImage"] will point to the image in the local registry,
+			// then localImages[defaultImage] will point to the image in the local registry,
 			// and there will be only one platform (i.e., the platform of the running machine) available for that image in the local registry.
 			// As a result, to make this test case not flaky even when SetupLocalRegistry is used,
-			// we need to pull alpineImage instead of localImages["defaultImage"]
+			// we need to pull alpineImage instead of localImages[defaultImage]
 			// because we can be sure that the registry associated with the former provides the image with the platform specified below.
 			ginkgo.It("build basic alpine image with --platform option", func() {
 				command.Run(o, "build", "-t", testImageName, "--platform=amd64", buildContext)

--- a/tests/builder_prune.go
+++ b/tests/builder_prune.go
@@ -21,7 +21,7 @@ func BuilderPrune(o *option.Option) {
 		ginkgo.BeforeEach(func() {
 			buildContext = ffs.CreateBuildContext(fmt.Sprintf(`FROM %s
 			CMD ["echo", "finch-test-dummy-output"]
-			`, localImages["defaultImage"]))
+			`, localImages[defaultImage]))
 			ginkgo.DeferCleanup(os.RemoveAll, buildContext)
 			command.RemoveAll(o)
 		})

--- a/tests/builder_prune.go
+++ b/tests/builder_prune.go
@@ -21,7 +21,7 @@ func BuilderPrune(o *option.Option) {
 		ginkgo.BeforeEach(func() {
 			buildContext = ffs.CreateBuildContext(fmt.Sprintf(`FROM %s
 			CMD ["echo", "finch-test-dummy-output"]
-			`, defaultImage))
+			`, localImages["defaultImage"]))
 			ginkgo.DeferCleanup(os.RemoveAll, buildContext)
 			command.RemoveAll(o)
 		})

--- a/tests/compose_build.go
+++ b/tests/compose_build.go
@@ -40,7 +40,7 @@ func ComposeBuild(o *option.Option) {
 			gomega.Expect(imageList).Should(gomega.ContainElement(gomega.HaveSuffix(imageSuffix[0])))
 			gomega.Expect(imageList).Should(gomega.ContainElement(gomega.HaveSuffix(imageSuffix[1])))
 			// The built image should print 'Compose build test' when run.
-			output := command.StdoutStr(o, "run", defaultImage)
+			output := command.StdoutStr(o, "run", localImages["defaultImage"])
 			gomega.Expect(output).Should(gomega.Equal("Compose build test"))
 		})
 
@@ -93,7 +93,7 @@ ARG CMD_MSG="Compose build test"
 RUN printf "should only see the final answer when '--progress' is set to be 'plain': %%d\n" $(expr 1 + 1) 
 ENV ENV_CMD_MSG=${CMD_MSG}
 CMD echo ${ENV_CMD_MSG}
-`, defaultImage)
+`, localImages["defaultImage"])
 
 	composeYmlContent := fmt.Sprintf(
 		`
@@ -107,7 +107,7 @@ services:
     build: 
       context: .
       dockerfile: Dockerfile
-`, serviceNames[0], serviceNames[1], defaultImage)
+`, serviceNames[0], serviceNames[1], localImages["defaultImage"])
 
 	composeDir, composeFilePath := ffs.CreateComposeYmlContext(composeYmlContent)
 	ffs.WriteFile(filepath.Join(composeDir, "Dockerfile"), dockerFileContent)

--- a/tests/compose_build.go
+++ b/tests/compose_build.go
@@ -40,7 +40,7 @@ func ComposeBuild(o *option.Option) {
 			gomega.Expect(imageList).Should(gomega.ContainElement(gomega.HaveSuffix(imageSuffix[0])))
 			gomega.Expect(imageList).Should(gomega.ContainElement(gomega.HaveSuffix(imageSuffix[1])))
 			// The built image should print 'Compose build test' when run.
-			output := command.StdoutStr(o, "run", localImages["defaultImage"])
+			output := command.StdoutStr(o, "run", localImages[defaultImage])
 			gomega.Expect(output).Should(gomega.Equal("Compose build test"))
 		})
 
@@ -93,7 +93,7 @@ ARG CMD_MSG="Compose build test"
 RUN printf "should only see the final answer when '--progress' is set to be 'plain': %%d\n" $(expr 1 + 1) 
 ENV ENV_CMD_MSG=${CMD_MSG}
 CMD echo ${ENV_CMD_MSG}
-`, localImages["defaultImage"])
+`, localImages[defaultImage])
 
 	composeYmlContent := fmt.Sprintf(
 		`
@@ -107,7 +107,7 @@ services:
     build: 
       context: .
       dockerfile: Dockerfile
-`, serviceNames[0], serviceNames[1], localImages["defaultImage"])
+`, serviceNames[0], serviceNames[1], localImages[defaultImage])
 
 	composeDir, composeFilePath := ffs.CreateComposeYmlContext(composeYmlContent)
 	ffs.WriteFile(filepath.Join(composeDir, "Dockerfile"), dockerFileContent)

--- a/tests/compose_down.go
+++ b/tests/compose_down.go
@@ -94,6 +94,6 @@ services:
       - compose_data_volume:/usr/local/data
 volumes:
   compose_data_volume:
-`, serviceNames[0], serviceNames[1], defaultImage, containerNames[0], containerNames[1])
+`, serviceNames[0], serviceNames[1], localImages["defaultImage"], containerNames[0], containerNames[1])
 	return ffs.CreateComposeYmlContext(composeYmlContent)
 }

--- a/tests/compose_down.go
+++ b/tests/compose_down.go
@@ -94,6 +94,6 @@ services:
       - compose_data_volume:/usr/local/data
 volumes:
   compose_data_volume:
-`, serviceNames[0], serviceNames[1], localImages["defaultImage"], containerNames[0], containerNames[1])
+`, serviceNames[0], serviceNames[1], localImages[defaultImage], containerNames[0], containerNames[1])
 	return ffs.CreateComposeYmlContext(composeYmlContent)
 }

--- a/tests/compose_kill.go
+++ b/tests/compose_kill.go
@@ -71,6 +71,6 @@ services:
     image: "%[3]s"
     container_name: "%[5]s"
     command: sleep infinity
-`, serviceNames[0], serviceNames[1], localImages["defaultImage"], containerNames[0], containerNames[1])
+`, serviceNames[0], serviceNames[1], localImages[defaultImage], containerNames[0], containerNames[1])
 	return ffs.CreateComposeYmlContext(composeYmlContent)
 }

--- a/tests/compose_kill.go
+++ b/tests/compose_kill.go
@@ -71,6 +71,6 @@ services:
     image: "%[3]s"
     container_name: "%[5]s"
     command: sleep infinity
-`, serviceNames[0], serviceNames[1], defaultImage, containerNames[0], containerNames[1])
+`, serviceNames[0], serviceNames[1], localImages["defaultImage"], containerNames[0], containerNames[1])
 	return ffs.CreateComposeYmlContext(composeYmlContent)
 }

--- a/tests/compose_logs.go
+++ b/tests/compose_logs.go
@@ -19,7 +19,7 @@ import (
 func ComposeLogs(o *option.Option) {
 	services := []string{"svc1_compose_logs", "svc2_compose_logs"}
 	containerNames := []string{"container1_compose_logs", "container2_compose_logs"}
-	imageNames := []string{defaultImage, defaultImage}
+	imageNames := []string{localImages["defaultImage"], localImages["defaultImage"]}
 
 	ginkgo.Describe("Compose logs command", func() {
 		var buildContext string

--- a/tests/compose_logs.go
+++ b/tests/compose_logs.go
@@ -19,7 +19,7 @@ import (
 func ComposeLogs(o *option.Option) {
 	services := []string{"svc1_compose_logs", "svc2_compose_logs"}
 	containerNames := []string{"container1_compose_logs", "container2_compose_logs"}
-	imageNames := []string{localImages["defaultImage"], localImages["defaultImage"]}
+	imageNames := []string{localImages[defaultImage], localImages[defaultImage]}
 
 	ginkgo.Describe("Compose logs command", func() {
 		var buildContext string

--- a/tests/compose_ps.go
+++ b/tests/compose_ps.go
@@ -19,7 +19,7 @@ import (
 func ComposePs(o *option.Option) {
 	services := []string{"svc1_compose_ps", "svc2_compose_ps"}
 	containerNames := []string{"container1_compose_ps", "container2_compose_ps"}
-	imageNames := []string{defaultImage, defaultImage}
+	imageNames := []string{localImages["defaultImage"], localImages["defaultImage"]}
 
 	ginkgo.Describe("Compose ps command", func() {
 		var composeContext string

--- a/tests/compose_ps.go
+++ b/tests/compose_ps.go
@@ -19,7 +19,7 @@ import (
 func ComposePs(o *option.Option) {
 	services := []string{"svc1_compose_ps", "svc2_compose_ps"}
 	containerNames := []string{"container1_compose_ps", "container2_compose_ps"}
-	imageNames := []string{localImages["defaultImage"], localImages["defaultImage"]}
+	imageNames := []string{localImages[defaultImage], localImages[defaultImage]}
 
 	ginkgo.Describe("Compose ps command", func() {
 		var composeContext string

--- a/tests/compose_pull.go
+++ b/tests/compose_pull.go
@@ -18,7 +18,7 @@ import (
 // ComposePull tests functionality of `compose pull` command.
 func ComposePull(o *option.Option) {
 	services := []string{"svc1_compose_pull", "svc2_compose_pull"}
-	imageNames := []string{defaultImage, olderAlpineImage}
+	imageNames := []string{localImages["defaultImage"], localImages["olderAlpineImage"]}
 	ginkgo.Describe("Compose pull command", func() {
 		var composeContext string
 		var composeFilePath string

--- a/tests/compose_pull.go
+++ b/tests/compose_pull.go
@@ -18,7 +18,7 @@ import (
 // ComposePull tests functionality of `compose pull` command.
 func ComposePull(o *option.Option) {
 	services := []string{"svc1_compose_pull", "svc2_compose_pull"}
-	imageNames := []string{localImages["defaultImage"], localImages["olderAlpineImage"]}
+	imageNames := []string{localImages[defaultImage], localImages[olderAlpineImage]}
 	ginkgo.Describe("Compose pull command", func() {
 		var composeContext string
 		var composeFilePath string

--- a/tests/cp.go
+++ b/tests/cp.go
@@ -33,7 +33,7 @@ func Cp(o *option.Option) {
 
 		ginkgo.When("the container is running", func() {
 			ginkgo.BeforeEach(func() {
-				command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "sleep", "infinity")
+				command.Run(o, "run", "-d", "--name", testContainerName, localImages[defaultImage], "sleep", "infinity")
 			})
 
 			ginkgo.It("should be able to copy file from host to container", func() {
@@ -105,7 +105,7 @@ func Cp(o *option.Option) {
 
 		ginkgo.When("the container is not running", func() {
 			ginkgo.It("should be able to copy file from host to container", func() {
-				command.Run(o, "run", "--name", testContainerName, localImages["defaultImage"], "sleep", "5")
+				command.Run(o, "run", "--name", testContainerName, localImages[defaultImage], "sleep", "5")
 				command.Run(o, "stop", testContainerName)
 				path := ffs.CreateTempFile(filename, content)
 				ginkgo.DeferCleanup(os.RemoveAll, filepath.Dir(path))
@@ -119,7 +119,7 @@ func Cp(o *option.Option) {
 
 			ginkgo.It("should be able to copy file from container to host", func() {
 				cmd := fmt.Sprintf("echo -n %s > %s", content, containerFilepath)
-				command.Run(o, "run", "--name", testContainerName, localImages["defaultImage"], "sh", "-c", cmd)
+				command.Run(o, "run", "--name", testContainerName, localImages[defaultImage], "sh", "-c", cmd)
 				fileDir := ffs.CreateTempDir("finch-test")
 				path := filepath.Join(fileDir, filename)
 				ginkgo.DeferCleanup(os.RemoveAll, fileDir)

--- a/tests/cp.go
+++ b/tests/cp.go
@@ -33,7 +33,7 @@ func Cp(o *option.Option) {
 
 		ginkgo.When("the container is running", func() {
 			ginkgo.BeforeEach(func() {
-				command.Run(o, "run", "-d", "--name", testContainerName, defaultImage, "sleep", "infinity")
+				command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "sleep", "infinity")
 			})
 
 			ginkgo.It("should be able to copy file from host to container", func() {
@@ -105,7 +105,7 @@ func Cp(o *option.Option) {
 
 		ginkgo.When("the container is not running", func() {
 			ginkgo.It("should be able to copy file from host to container", func() {
-				command.Run(o, "run", "--name", testContainerName, defaultImage, "sleep", "5")
+				command.Run(o, "run", "--name", testContainerName, localImages["defaultImage"], "sleep", "5")
 				command.Run(o, "stop", testContainerName)
 				path := ffs.CreateTempFile(filename, content)
 				ginkgo.DeferCleanup(os.RemoveAll, filepath.Dir(path))
@@ -119,7 +119,7 @@ func Cp(o *option.Option) {
 
 			ginkgo.It("should be able to copy file from container to host", func() {
 				cmd := fmt.Sprintf("echo -n %s > %s", content, containerFilepath)
-				command.Run(o, "run", "--name", testContainerName, defaultImage, "sh", "-c", cmd)
+				command.Run(o, "run", "--name", testContainerName, localImages["defaultImage"], "sh", "-c", cmd)
 				fileDir := ffs.CreateTempDir("finch-test")
 				path := filepath.Join(fileDir, filename)
 				ginkgo.DeferCleanup(os.RemoveAll, fileDir)

--- a/tests/create.go
+++ b/tests/create.go
@@ -24,7 +24,7 @@ func Create(o *option.Option) {
 		})
 
 		ginkgo.It("should create a container and able to start the container", func() {
-			command.Run(o, "create", "--name", testContainerName, defaultImage, "sleep", "infinity")
+			command.Run(o, "create", "--name", testContainerName, localImages["defaultImage"], "sleep", "infinity")
 			status := command.StdoutStr(o, "ps", "-a", "--filter", fmt.Sprintf("name=%s", testContainerName), "--format", "{{.Status}}")
 			gomega.Expect(status).Should(gomega.Equal("Created"))
 

--- a/tests/create.go
+++ b/tests/create.go
@@ -24,7 +24,7 @@ func Create(o *option.Option) {
 		})
 
 		ginkgo.It("should create a container and able to start the container", func() {
-			command.Run(o, "create", "--name", testContainerName, localImages["defaultImage"], "sleep", "infinity")
+			command.Run(o, "create", "--name", testContainerName, localImages[defaultImage], "sleep", "infinity")
 			status := command.StdoutStr(o, "ps", "-a", "--filter", fmt.Sprintf("name=%s", testContainerName), "--format", "{{.Status}}")
 			gomega.Expect(status).Should(gomega.Equal("Created"))
 

--- a/tests/events.go
+++ b/tests/events.go
@@ -29,14 +29,14 @@ func Events(o *option.Option) {
 			session := command.RunWithoutWait(o, "system", "events")
 			defer session.Kill()
 			gomega.Expect(session.Out.Contents()).Should(gomega.BeEmpty())
-			command.Run(o, "pull", defaultImage)
+			command.Run(o, "pull", localImages["defaultImage"])
 			// allow propagation time
 			gomega.Eventually(func(session *gexec.Session) string {
 				return strings.TrimSpace(string(session.Out.Contents()))
 			}).WithArguments(session).
 				WithTimeout(15 * time.Second).
 				WithPolling(1 * time.Second).
-				Should(gomega.ContainSubstring(defaultImage))
+				Should(gomega.ContainSubstring(localImages["defaultImage"]))
 		})
 	})
 }

--- a/tests/events.go
+++ b/tests/events.go
@@ -29,14 +29,14 @@ func Events(o *option.Option) {
 			session := command.RunWithoutWait(o, "system", "events")
 			defer session.Kill()
 			gomega.Expect(session.Out.Contents()).Should(gomega.BeEmpty())
-			command.Run(o, "pull", localImages["defaultImage"])
+			command.Run(o, "pull", localImages[defaultImage])
 			// allow propagation time
 			gomega.Eventually(func(session *gexec.Session) string {
 				return strings.TrimSpace(string(session.Out.Contents()))
 			}).WithArguments(session).
 				WithTimeout(15 * time.Second).
 				WithPolling(1 * time.Second).
-				Should(gomega.ContainSubstring(localImages["defaultImage"]))
+				Should(gomega.ContainSubstring(localImages[defaultImage]))
 		})
 	})
 }

--- a/tests/exec.go
+++ b/tests/exec.go
@@ -29,7 +29,7 @@ func Exec(o *option.Option) {
 		// TODO: specifying -t flag will have error in test -> panic: provided file is not a console
 		ginkgo.When("then container is running", func() {
 			ginkgo.BeforeEach(func() {
-				command.Run(o, "run", "-d", "--name", testContainerName, defaultImage, "sleep", "infinity")
+				command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "sleep", "infinity")
 			})
 
 			ginkgo.It("should execute a command in a running container", func() {
@@ -109,7 +109,7 @@ func Exec(o *option.Option) {
 		})
 
 		ginkgo.It("should not execute a command when the container is not running", func() {
-			command.Run(o, "run", "--name", testContainerName, defaultImage)
+			command.Run(o, "run", "--name", testContainerName, localImages["defaultImage"])
 			command.RunWithoutSuccessfulExit(o, "exec", testContainerName)
 		})
 	})

--- a/tests/exec.go
+++ b/tests/exec.go
@@ -29,7 +29,7 @@ func Exec(o *option.Option) {
 		// TODO: specifying -t flag will have error in test -> panic: provided file is not a console
 		ginkgo.When("then container is running", func() {
 			ginkgo.BeforeEach(func() {
-				command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "sleep", "infinity")
+				command.Run(o, "run", "-d", "--name", testContainerName, localImages[defaultImage], "sleep", "infinity")
 			})
 
 			ginkgo.It("should execute a command in a running container", func() {
@@ -109,7 +109,7 @@ func Exec(o *option.Option) {
 		})
 
 		ginkgo.It("should not execute a command when the container is not running", func() {
-			command.Run(o, "run", "--name", testContainerName, localImages["defaultImage"])
+			command.Run(o, "run", "--name", testContainerName, localImages[defaultImage])
 			command.RunWithoutSuccessfulExit(o, "exec", testContainerName)
 		})
 	})

--- a/tests/image_history.go
+++ b/tests/image_history.go
@@ -22,7 +22,7 @@ func ImageHistory(o *option.Option) {
 	ginkgo.Describe("show the history of an image", func() {
 		ginkgo.BeforeEach(func() {
 			command.RemoveAll(o)
-			pullImage(o, defaultImage)
+			pullImage(o, localImages["defaultImage"])
 		})
 
 		ginkgo.AfterEach(func() {
@@ -30,19 +30,19 @@ func ImageHistory(o *option.Option) {
 		})
 
 		ginkgo.It("should display image history", func() {
-			gomega.Expect(command.StdoutStr(o, "image", "history", defaultImage)).ShouldNot(gomega.BeEmpty())
+			gomega.Expect(command.StdoutStr(o, "image", "history", localImages["defaultImage"])).ShouldNot(gomega.BeEmpty())
 		})
 
 		for _, quiet := range []string{"-q", "--quiet"} {
 			quiet := quiet
 			ginkgo.It(fmt.Sprintf("should only display snapshot ID with %s flag", quiet), func() {
-				ids := removeMissingID(command.StdoutAsLines(o, "image", "history", quiet, defaultImage))
+				ids := removeMissingID(command.StdoutAsLines(o, "image", "history", quiet, localImages["defaultImage"]))
 				gomega.Expect(ids).Should(gomega.HaveEach(gomega.MatchRegexp(sha256RegexFull)))
 			})
 		}
 
 		ginkgo.It("should only display snapshot ID with --format flag", func() {
-			ids := removeMissingID(command.StdoutAsLines(o, "image", "history", defaultImage, "--format", "{{.Snapshot}}"))
+			ids := removeMissingID(command.StdoutAsLines(o, "image", "history", localImages["defaultImage"], "--format", "{{.Snapshot}}"))
 			gomega.Expect(ids).Should(gomega.HaveEach(gomega.MatchRegexp(sha256RegexFull)))
 		})
 
@@ -50,7 +50,7 @@ func ImageHistory(o *option.Option) {
 			const text = "a very very very very long test phrase that only serves for testing purpose"
 			buildContext := ffs.CreateBuildContext(fmt.Sprintf(`FROM %s
 			CMD ["echo", %s]
-			`, defaultImage, text))
+			`, localImages["defaultImage"], text))
 			ginkgo.DeferCleanup(os.RemoveAll, buildContext)
 
 			command.Run(o, "build", "-t", testImageName, buildContext)

--- a/tests/image_history.go
+++ b/tests/image_history.go
@@ -22,7 +22,7 @@ func ImageHistory(o *option.Option) {
 	ginkgo.Describe("show the history of an image", func() {
 		ginkgo.BeforeEach(func() {
 			command.RemoveAll(o)
-			pullImage(o, localImages["defaultImage"])
+			pullImage(o, localImages[defaultImage])
 		})
 
 		ginkgo.AfterEach(func() {
@@ -30,19 +30,19 @@ func ImageHistory(o *option.Option) {
 		})
 
 		ginkgo.It("should display image history", func() {
-			gomega.Expect(command.StdoutStr(o, "image", "history", localImages["defaultImage"])).ShouldNot(gomega.BeEmpty())
+			gomega.Expect(command.StdoutStr(o, "image", "history", localImages[defaultImage])).ShouldNot(gomega.BeEmpty())
 		})
 
 		for _, quiet := range []string{"-q", "--quiet"} {
 			quiet := quiet
 			ginkgo.It(fmt.Sprintf("should only display snapshot ID with %s flag", quiet), func() {
-				ids := removeMissingID(command.StdoutAsLines(o, "image", "history", quiet, localImages["defaultImage"]))
+				ids := removeMissingID(command.StdoutAsLines(o, "image", "history", quiet, localImages[defaultImage]))
 				gomega.Expect(ids).Should(gomega.HaveEach(gomega.MatchRegexp(sha256RegexFull)))
 			})
 		}
 
 		ginkgo.It("should only display snapshot ID with --format flag", func() {
-			ids := removeMissingID(command.StdoutAsLines(o, "image", "history", localImages["defaultImage"], "--format", "{{.Snapshot}}"))
+			ids := removeMissingID(command.StdoutAsLines(o, "image", "history", localImages[defaultImage], "--format", "{{.Snapshot}}"))
 			gomega.Expect(ids).Should(gomega.HaveEach(gomega.MatchRegexp(sha256RegexFull)))
 		})
 
@@ -50,7 +50,7 @@ func ImageHistory(o *option.Option) {
 			const text = "a very very very very long test phrase that only serves for testing purpose"
 			buildContext := ffs.CreateBuildContext(fmt.Sprintf(`FROM %s
 			CMD ["echo", %s]
-			`, localImages["defaultImage"], text))
+			`, localImages[defaultImage], text))
 			ginkgo.DeferCleanup(os.RemoveAll, buildContext)
 
 			command.Run(o, "build", "-t", testImageName, buildContext)

--- a/tests/image_inspect.go
+++ b/tests/image_inspect.go
@@ -16,25 +16,25 @@ func ImageInspect(o *option.Option) {
 	ginkgo.Describe("display detailed information on one or more images", func() {
 		ginkgo.BeforeEach(func() {
 			command.RemoveAll(o)
-			pullImage(o, defaultImage)
+			pullImage(o, localImages["defaultImage"])
 		})
 		ginkgo.AfterEach(func() {
 			command.RemoveAll(o)
 		})
 
 		ginkgo.It("should display detailed information on an image", func() {
-			gomega.Expect(command.StdoutStr(o, "image", "inspect", defaultImage)).ShouldNot(gomega.BeEmpty())
+			gomega.Expect(command.StdoutStr(o, "image", "inspect", localImages["defaultImage"])).ShouldNot(gomega.BeEmpty())
 		})
 
 		ginkgo.It("should display image RepoTags with --format flag", func() {
-			image := command.StdoutStr(o, "image", "inspect", defaultImage, "--format", "{{(index .RepoTags 0)}}")
-			gomega.Expect(image).Should(gomega.Equal(defaultImage))
+			image := command.StdoutStr(o, "image", "inspect", localImages["defaultImage"], "--format", "{{(index .RepoTags 0)}}")
+			gomega.Expect(image).Should(gomega.Equal(localImages["defaultImage"]))
 		})
 
 		ginkgo.It("should display multiple image RepoTags with --format flag", func() {
-			pullImage(o, olderAlpineImage)
-			lines := command.StdoutAsLines(o, "image", "inspect", defaultImage, olderAlpineImage, "--format", "{{(index .RepoTags 0)}}")
-			gomega.Expect(lines).Should(gomega.ConsistOf(defaultImage, olderAlpineImage))
+			pullImage(o, localImages["olderAlpineImage"])
+			lines := command.StdoutAsLines(o, "image", "inspect", localImages["defaultImage"], localImages["olderAlpineImage"], "--format", "{{(index .RepoTags 0)}}")
+			gomega.Expect(lines).Should(gomega.ConsistOf(localImages["defaultImage"], localImages["olderAlpineImage"]))
 		})
 
 		ginkgo.It("should not display information if image doesn't exist", func() {

--- a/tests/image_inspect.go
+++ b/tests/image_inspect.go
@@ -16,25 +16,33 @@ func ImageInspect(o *option.Option) {
 	ginkgo.Describe("display detailed information on one or more images", func() {
 		ginkgo.BeforeEach(func() {
 			command.RemoveAll(o)
-			pullImage(o, localImages["defaultImage"])
+			pullImage(o, localImages[defaultImage])
 		})
 		ginkgo.AfterEach(func() {
 			command.RemoveAll(o)
 		})
 
 		ginkgo.It("should display detailed information on an image", func() {
-			gomega.Expect(command.StdoutStr(o, "image", "inspect", localImages["defaultImage"])).ShouldNot(gomega.BeEmpty())
+			gomega.Expect(command.StdoutStr(o, "image", "inspect", localImages[defaultImage])).ShouldNot(gomega.BeEmpty())
 		})
 
 		ginkgo.It("should display image RepoTags with --format flag", func() {
-			image := command.StdoutStr(o, "image", "inspect", localImages["defaultImage"], "--format", "{{(index .RepoTags 0)}}")
-			gomega.Expect(image).Should(gomega.Equal(localImages["defaultImage"]))
+			image := command.StdoutStr(o, "image", "inspect", localImages[defaultImage], "--format", "{{(index .RepoTags 0)}}")
+			gomega.Expect(image).Should(gomega.Equal(localImages[defaultImage]))
 		})
 
 		ginkgo.It("should display multiple image RepoTags with --format flag", func() {
-			pullImage(o, localImages["olderAlpineImage"])
-			lines := command.StdoutAsLines(o, "image", "inspect", localImages["defaultImage"], localImages["olderAlpineImage"], "--format", "{{(index .RepoTags 0)}}")
-			gomega.Expect(lines).Should(gomega.ConsistOf(localImages["defaultImage"], localImages["olderAlpineImage"]))
+			pullImage(o, localImages[olderAlpineImage])
+			lines := command.StdoutAsLines(
+				o,
+				"image",
+				"inspect",
+				localImages[defaultImage],
+				localImages[olderAlpineImage],
+				"--format",
+				"{{(index .RepoTags 0)}}",
+			)
+			gomega.Expect(lines).Should(gomega.ConsistOf(localImages[defaultImage], localImages[olderAlpineImage]))
 		})
 
 		ginkgo.It("should not display information if image doesn't exist", func() {

--- a/tests/image_prune.go
+++ b/tests/image_prune.go
@@ -21,38 +21,38 @@ func ImagePrune(o *option.Option) {
 	ginkgo.Describe("Remove unused images", func() {
 		ginkgo.BeforeEach(func() {
 			command.RemoveAll(o)
-			pullImage(o, defaultImage)
+			pullImage(o, localImages["defaultImage"])
 		})
 		ginkgo.AfterEach(func() {
 			command.RemoveAll(o)
 		})
 
 		ginkgo.It("should remove all unused images with inputting y in prompt confirmation", func() {
-			imageShouldExist(o, defaultImage)
+			imageShouldExist(o, localImages["defaultImage"])
 			command.New(o, "image", "prune", "-a").WithStdin(gbytes.BufferWithBytes([]byte("y"))).Run()
-			imageShouldNotExist(o, defaultImage)
+			imageShouldNotExist(o, localImages["defaultImage"])
 		})
 
 		ginkgo.It("should not remove any unused image with inputting n in prompt confirmation", func() {
-			imageShouldExist(o, defaultImage)
+			imageShouldExist(o, localImages["defaultImage"])
 			command.New(o, "image", "prune", "-a").WithStdin(gbytes.BufferWithBytes([]byte("n"))).Run()
-			imageShouldExist(o, defaultImage)
+			imageShouldExist(o, localImages["defaultImage"])
 		})
 
 		for _, force := range []string{"-f", "--force"} {
 			force := force
 			ginkgo.It(fmt.Sprintf("with %s flag, should remove unused images without prompting a confirmation", force), func() {
-				imageShouldExist(o, defaultImage)
+				imageShouldExist(o, localImages["defaultImage"])
 				command.Run(o, "image", "prune", "-a", "-f")
-				imageShouldNotExist(o, defaultImage)
+				imageShouldNotExist(o, localImages["defaultImage"])
 			})
 		}
 
 		ginkgo.It("should not remove an image if it's used by a dead container", func() {
-			command.Run(o, "run", defaultImage)
-			imageShouldExist(o, defaultImage)
+			command.Run(o, "run", localImages["defaultImage"])
+			imageShouldExist(o, localImages["defaultImage"])
 			command.Run(o, "image", "prune", "-a", "-f")
-			imageShouldExist(o, defaultImage)
+			imageShouldExist(o, localImages["defaultImage"])
 		})
 	})
 }

--- a/tests/image_prune.go
+++ b/tests/image_prune.go
@@ -21,38 +21,38 @@ func ImagePrune(o *option.Option) {
 	ginkgo.Describe("Remove unused images", func() {
 		ginkgo.BeforeEach(func() {
 			command.RemoveAll(o)
-			pullImage(o, localImages["defaultImage"])
+			pullImage(o, localImages[defaultImage])
 		})
 		ginkgo.AfterEach(func() {
 			command.RemoveAll(o)
 		})
 
 		ginkgo.It("should remove all unused images with inputting y in prompt confirmation", func() {
-			imageShouldExist(o, localImages["defaultImage"])
+			imageShouldExist(o, localImages[defaultImage])
 			command.New(o, "image", "prune", "-a").WithStdin(gbytes.BufferWithBytes([]byte("y"))).Run()
-			imageShouldNotExist(o, localImages["defaultImage"])
+			imageShouldNotExist(o, localImages[defaultImage])
 		})
 
 		ginkgo.It("should not remove any unused image with inputting n in prompt confirmation", func() {
-			imageShouldExist(o, localImages["defaultImage"])
+			imageShouldExist(o, localImages[defaultImage])
 			command.New(o, "image", "prune", "-a").WithStdin(gbytes.BufferWithBytes([]byte("n"))).Run()
-			imageShouldExist(o, localImages["defaultImage"])
+			imageShouldExist(o, localImages[defaultImage])
 		})
 
 		for _, force := range []string{"-f", "--force"} {
 			force := force
 			ginkgo.It(fmt.Sprintf("with %s flag, should remove unused images without prompting a confirmation", force), func() {
-				imageShouldExist(o, localImages["defaultImage"])
+				imageShouldExist(o, localImages[defaultImage])
 				command.Run(o, "image", "prune", "-a", "-f")
-				imageShouldNotExist(o, localImages["defaultImage"])
+				imageShouldNotExist(o, localImages[defaultImage])
 			})
 		}
 
 		ginkgo.It("should not remove an image if it's used by a dead container", func() {
-			command.Run(o, "run", localImages["defaultImage"])
-			imageShouldExist(o, localImages["defaultImage"])
+			command.Run(o, "run", localImages[defaultImage])
+			imageShouldExist(o, localImages[defaultImage])
 			command.Run(o, "image", "prune", "-a", "-f")
-			imageShouldExist(o, localImages["defaultImage"])
+			imageShouldExist(o, localImages[defaultImage])
 		})
 	})
 }

--- a/tests/images.go
+++ b/tests/images.go
@@ -17,13 +17,13 @@ func Images(o *option.Option) {
 	ginkgo.Describe("list container images", ginkgo.Ordered, func() {
 		testImageName := "fn-test-images-cmd:latest"
 		ginkgo.BeforeAll(func() {
-			pullImage(o, localImages["defaultImage"])
+			pullImage(o, localImages[defaultImage])
 			buildImage(o, testImageName)
 		})
 
 		ginkgo.AfterAll(func() {
 			removeImage(o, testImageName)
-			removeImage(o, localImages["defaultImage"])
+			removeImage(o, localImages[defaultImage])
 		})
 
 		ginkgo.It("should list all the images in a tabular format", func() {
@@ -47,7 +47,7 @@ func Images(o *option.Option) {
 			images := command.StdoutAsLines(o, "images", "--format", "{{.Repository}}:{{.Tag}}")
 			gomega.Expect(images).ShouldNot(gomega.BeEmpty())
 			gomega.Expect(images).Should(gomega.ContainElements(testImageName))
-			gomega.Expect(images).Should(gomega.ContainElements(localImages["defaultImage"]))
+			gomega.Expect(images).Should(gomega.ContainElements(localImages[defaultImage]))
 		})
 		ginkgo.It("should list truncated IMAGE IDs", func() {
 			images := command.StdoutAsLines(o, "images", "--quiet")

--- a/tests/images.go
+++ b/tests/images.go
@@ -17,13 +17,13 @@ func Images(o *option.Option) {
 	ginkgo.Describe("list container images", ginkgo.Ordered, func() {
 		testImageName := "fn-test-images-cmd:latest"
 		ginkgo.BeforeAll(func() {
-			pullImage(o, defaultImage)
+			pullImage(o, localImages["defaultImage"])
 			buildImage(o, testImageName)
 		})
 
 		ginkgo.AfterAll(func() {
 			removeImage(o, testImageName)
-			removeImage(o, defaultImage)
+			removeImage(o, localImages["defaultImage"])
 		})
 
 		ginkgo.It("should list all the images in a tabular format", func() {
@@ -47,7 +47,7 @@ func Images(o *option.Option) {
 			images := command.StdoutAsLines(o, "images", "--format", "{{.Repository}}:{{.Tag}}")
 			gomega.Expect(images).ShouldNot(gomega.BeEmpty())
 			gomega.Expect(images).Should(gomega.ContainElements(testImageName))
-			gomega.Expect(images).Should(gomega.ContainElements(defaultImage))
+			gomega.Expect(images).Should(gomega.ContainElements(localImages["defaultImage"]))
 		})
 		ginkgo.It("should list truncated IMAGE IDs", func() {
 			images := command.StdoutAsLines(o, "images", "--quiet")

--- a/tests/inspect.go
+++ b/tests/inspect.go
@@ -22,9 +22,9 @@ func Inspect(o *option.Option) {
 		})
 
 		ginkgo.It("should display the detailed information of a container", func() {
-			command.Run(o, "run", "--name", testContainerName, defaultImage)
+			command.Run(o, "run", "--name", testContainerName, localImages["defaultImage"])
 			image := command.StdoutStr(o, "inspect", "--format", "{{.Image}}", testContainerName)
-			gomega.Expect(image).To(gomega.Equal(defaultImage))
+			gomega.Expect(image).To(gomega.Equal(localImages["defaultImage"]))
 			containerName := command.StdoutStr(o, "inspect", "--format", "{{.Name}}", testContainerName)
 			gomega.Expect(containerName).To(gomega.Equal(testContainerName))
 			gomega.Expect(command.StdoutStr(o, "inspect", "--format", "{{.State.Status}}", testContainerName)).To(gomega.Equal("exited"))
@@ -33,10 +33,10 @@ func Inspect(o *option.Option) {
 
 		ginkgo.It("should display multiple container image with --format flag", func() {
 			const oldContainerName = "ctr-old"
-			command.Run(o, "run", "--name", testContainerName, defaultImage)
-			command.Run(o, "run", "--name", oldContainerName, olderAlpineImage)
+			command.Run(o, "run", "--name", testContainerName, localImages["defaultImage"])
+			command.Run(o, "run", "--name", oldContainerName, localImages["olderAlpineImage"])
 			images := command.StdoutAsLines(o, "inspect", "--format", "{{.Image}}", testContainerName, oldContainerName)
-			gomega.Expect(images).Should(gomega.ConsistOf(defaultImage, olderAlpineImage))
+			gomega.Expect(images).Should(gomega.ConsistOf(localImages["defaultImage"], localImages["olderAlpineImage"]))
 		})
 
 		ginkgo.It("should have an error if inspect a non-existing container", func() {
@@ -44,21 +44,21 @@ func Inspect(o *option.Option) {
 		})
 
 		ginkgo.It("should show the information of a container with --type=container flag", func() {
-			command.Run(o, "run", "--name", testContainerName, defaultImage)
+			command.Run(o, "run", "--name", testContainerName, localImages["defaultImage"])
 			image := command.StdoutStr(o, "inspect", "--type", "container", testContainerName, "--format", "{{.Image}}")
-			gomega.Expect(image).Should(gomega.Equal(defaultImage))
+			gomega.Expect(image).Should(gomega.Equal(localImages["defaultImage"]))
 			containerName := command.StdoutStr(o, "inspect", "--format", "{{.Name}}", testContainerName)
 			gomega.Expect(containerName).Should(gomega.Equal(testContainerName))
 		})
 
 		ginkgo.It("should show the information of an image with --type=image flag", func() {
-			pullImage(o, defaultImage)
-			image := command.StdoutStr(o, "inspect", "--type", "image", defaultImage, "--format", "{{(index .RepoTags 0)}}")
-			gomega.Expect(image).Should(gomega.Equal(defaultImage))
+			pullImage(o, localImages["defaultImage"])
+			image := command.StdoutStr(o, "inspect", "--type", "image", localImages["defaultImage"], "--format", "{{(index .RepoTags 0)}}")
+			gomega.Expect(image).Should(gomega.Equal(localImages["defaultImage"]))
 		})
 
 		ginkgo.It("should have an error if specify the wrong object type", func() {
-			command.Run(o, "run", "--name", testContainerName, defaultImage)
+			command.Run(o, "run", "--name", testContainerName, localImages["defaultImage"])
 			command.RunWithoutSuccessfulExit(o, "inspect", "--type", "image", testContainerName)
 		})
 

--- a/tests/inspect.go
+++ b/tests/inspect.go
@@ -22,9 +22,9 @@ func Inspect(o *option.Option) {
 		})
 
 		ginkgo.It("should display the detailed information of a container", func() {
-			command.Run(o, "run", "--name", testContainerName, localImages["defaultImage"])
+			command.Run(o, "run", "--name", testContainerName, localImages[defaultImage])
 			image := command.StdoutStr(o, "inspect", "--format", "{{.Image}}", testContainerName)
-			gomega.Expect(image).To(gomega.Equal(localImages["defaultImage"]))
+			gomega.Expect(image).To(gomega.Equal(localImages[defaultImage]))
 			containerName := command.StdoutStr(o, "inspect", "--format", "{{.Name}}", testContainerName)
 			gomega.Expect(containerName).To(gomega.Equal(testContainerName))
 			gomega.Expect(command.StdoutStr(o, "inspect", "--format", "{{.State.Status}}", testContainerName)).To(gomega.Equal("exited"))
@@ -33,10 +33,10 @@ func Inspect(o *option.Option) {
 
 		ginkgo.It("should display multiple container image with --format flag", func() {
 			const oldContainerName = "ctr-old"
-			command.Run(o, "run", "--name", testContainerName, localImages["defaultImage"])
-			command.Run(o, "run", "--name", oldContainerName, localImages["olderAlpineImage"])
+			command.Run(o, "run", "--name", testContainerName, localImages[defaultImage])
+			command.Run(o, "run", "--name", oldContainerName, localImages[olderAlpineImage])
 			images := command.StdoutAsLines(o, "inspect", "--format", "{{.Image}}", testContainerName, oldContainerName)
-			gomega.Expect(images).Should(gomega.ConsistOf(localImages["defaultImage"], localImages["olderAlpineImage"]))
+			gomega.Expect(images).Should(gomega.ConsistOf(localImages[defaultImage], localImages[olderAlpineImage]))
 		})
 
 		ginkgo.It("should have an error if inspect a non-existing container", func() {
@@ -44,21 +44,21 @@ func Inspect(o *option.Option) {
 		})
 
 		ginkgo.It("should show the information of a container with --type=container flag", func() {
-			command.Run(o, "run", "--name", testContainerName, localImages["defaultImage"])
+			command.Run(o, "run", "--name", testContainerName, localImages[defaultImage])
 			image := command.StdoutStr(o, "inspect", "--type", "container", testContainerName, "--format", "{{.Image}}")
-			gomega.Expect(image).Should(gomega.Equal(localImages["defaultImage"]))
+			gomega.Expect(image).Should(gomega.Equal(localImages[defaultImage]))
 			containerName := command.StdoutStr(o, "inspect", "--format", "{{.Name}}", testContainerName)
 			gomega.Expect(containerName).Should(gomega.Equal(testContainerName))
 		})
 
 		ginkgo.It("should show the information of an image with --type=image flag", func() {
-			pullImage(o, localImages["defaultImage"])
-			image := command.StdoutStr(o, "inspect", "--type", "image", localImages["defaultImage"], "--format", "{{(index .RepoTags 0)}}")
-			gomega.Expect(image).Should(gomega.Equal(localImages["defaultImage"]))
+			pullImage(o, localImages[defaultImage])
+			image := command.StdoutStr(o, "inspect", "--type", "image", localImages[defaultImage], "--format", "{{(index .RepoTags 0)}}")
+			gomega.Expect(image).Should(gomega.Equal(localImages[defaultImage]))
 		})
 
 		ginkgo.It("should have an error if specify the wrong object type", func() {
-			command.Run(o, "run", "--name", testContainerName, localImages["defaultImage"])
+			command.Run(o, "run", "--name", testContainerName, localImages[defaultImage])
 			command.RunWithoutSuccessfulExit(o, "inspect", "--type", "image", testContainerName)
 		})
 

--- a/tests/kill.go
+++ b/tests/kill.go
@@ -24,7 +24,7 @@ func Kill(o *option.Option) {
 
 		ginkgo.When("the container is running", func() {
 			ginkgo.BeforeEach(func() {
-				command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "sleep", "infinity")
+				command.Run(o, "run", "-d", "--name", testContainerName, localImages[defaultImage], "sleep", "infinity")
 			})
 
 			ginkgo.It("should kill the running container", func() {

--- a/tests/kill.go
+++ b/tests/kill.go
@@ -24,7 +24,7 @@ func Kill(o *option.Option) {
 
 		ginkgo.When("the container is running", func() {
 			ginkgo.BeforeEach(func() {
-				command.Run(o, "run", "-d", "--name", testContainerName, defaultImage, "sleep", "infinity")
+				command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "sleep", "infinity")
 			})
 
 			ginkgo.It("should kill the running container", func() {

--- a/tests/load.go
+++ b/tests/load.go
@@ -21,7 +21,7 @@ func Load(o *option.Option) {
 		var tarFilePath string
 		ginkgo.BeforeEach(func() {
 			command.RemoveAll(o)
-			pullImage(o, defaultImage)
+			pullImage(o, localImages["defaultImage"])
 			tarFilePath = ffs.CreateTarFilePath()
 			ginkgo.DeferCleanup(os.RemoveAll, filepath.Join(tarFilePath, "../"))
 		})
@@ -33,26 +33,26 @@ func Load(o *option.Option) {
 		for _, inputOption := range []string{"-i", "--input"} {
 			inputOption := inputOption
 			ginkgo.It(fmt.Sprintf("should load an image with %s option", inputOption), func() {
-				command.Run(o, "save", "-o", tarFilePath, defaultImage)
+				command.Run(o, "save", "-o", tarFilePath, localImages["defaultImage"])
 
-				command.Run(o, "rmi", defaultImage)
-				imageShouldNotExist(o, defaultImage)
+				command.Run(o, "rmi", localImages["defaultImage"])
+				imageShouldNotExist(o, localImages["defaultImage"])
 
 				command.Run(o, "load", inputOption, tarFilePath)
-				imageShouldExist(o, defaultImage)
+				imageShouldExist(o, localImages["defaultImage"])
 			})
 
 			ginkgo.It(fmt.Sprintf("should load multiple images with %s option", inputOption), func() {
-				pullImage(o, olderAlpineImage)
-				command.Run(o, "save", "-o", tarFilePath, defaultImage, olderAlpineImage)
+				pullImage(o, localImages["olderAlpineImage"])
+				command.Run(o, "save", "-o", tarFilePath, localImages["defaultImage"], localImages["olderAlpineImage"])
 
-				command.Run(o, "rmi", defaultImage, olderAlpineImage)
-				imageShouldNotExist(o, defaultImage)
-				imageShouldNotExist(o, olderAlpineImage)
+				command.Run(o, "rmi", localImages["defaultImage"], localImages["olderAlpineImage"])
+				imageShouldNotExist(o, localImages["defaultImage"])
+				imageShouldNotExist(o, localImages["olderAlpineImage"])
 
 				command.Run(o, "load", inputOption, tarFilePath)
-				imageShouldExist(o, defaultImage)
-				imageShouldExist(o, olderAlpineImage)
+				imageShouldExist(o, localImages["defaultImage"])
+				imageShouldExist(o, localImages["olderAlpineImage"])
 			})
 		}
 	})

--- a/tests/load.go
+++ b/tests/load.go
@@ -21,7 +21,7 @@ func Load(o *option.Option) {
 		var tarFilePath string
 		ginkgo.BeforeEach(func() {
 			command.RemoveAll(o)
-			pullImage(o, localImages["defaultImage"])
+			pullImage(o, localImages[defaultImage])
 			tarFilePath = ffs.CreateTarFilePath()
 			ginkgo.DeferCleanup(os.RemoveAll, filepath.Join(tarFilePath, "../"))
 		})
@@ -33,26 +33,26 @@ func Load(o *option.Option) {
 		for _, inputOption := range []string{"-i", "--input"} {
 			inputOption := inputOption
 			ginkgo.It(fmt.Sprintf("should load an image with %s option", inputOption), func() {
-				command.Run(o, "save", "-o", tarFilePath, localImages["defaultImage"])
+				command.Run(o, "save", "-o", tarFilePath, localImages[defaultImage])
 
-				command.Run(o, "rmi", localImages["defaultImage"])
-				imageShouldNotExist(o, localImages["defaultImage"])
+				command.Run(o, "rmi", localImages[defaultImage])
+				imageShouldNotExist(o, localImages[defaultImage])
 
 				command.Run(o, "load", inputOption, tarFilePath)
-				imageShouldExist(o, localImages["defaultImage"])
+				imageShouldExist(o, localImages[defaultImage])
 			})
 
 			ginkgo.It(fmt.Sprintf("should load multiple images with %s option", inputOption), func() {
-				pullImage(o, localImages["olderAlpineImage"])
-				command.Run(o, "save", "-o", tarFilePath, localImages["defaultImage"], localImages["olderAlpineImage"])
+				pullImage(o, localImages[olderAlpineImage])
+				command.Run(o, "save", "-o", tarFilePath, localImages[defaultImage], localImages[olderAlpineImage])
 
-				command.Run(o, "rmi", localImages["defaultImage"], localImages["olderAlpineImage"])
-				imageShouldNotExist(o, localImages["defaultImage"])
-				imageShouldNotExist(o, localImages["olderAlpineImage"])
+				command.Run(o, "rmi", localImages[defaultImage], localImages[olderAlpineImage])
+				imageShouldNotExist(o, localImages[defaultImage])
+				imageShouldNotExist(o, localImages[olderAlpineImage])
 
 				command.Run(o, "load", inputOption, tarFilePath)
-				imageShouldExist(o, localImages["defaultImage"])
-				imageShouldExist(o, localImages["olderAlpineImage"])
+				imageShouldExist(o, localImages[defaultImage])
+				imageShouldExist(o, localImages[olderAlpineImage])
 			})
 		}
 	})

--- a/tests/login.go
+++ b/tests/login.go
@@ -54,7 +54,7 @@ func Login(o *option.Option) {
 				tag = fmt.Sprintf(`%s/test-login:tag`, registry)
 				buildContext := ffs.CreateBuildContext(fmt.Sprintf(`FROM %s
 		CMD ["echo", "bar"]
-			`, localImages["defaultImage"]))
+			`, localImages[defaultImage]))
 				ginkgo.DeferCleanup(os.RemoveAll, buildContext)
 				command.Run(o, "build", "-t", tag, buildContext)
 			})

--- a/tests/login.go
+++ b/tests/login.go
@@ -54,7 +54,7 @@ func Login(o *option.Option) {
 				tag = fmt.Sprintf(`%s/test-login:tag`, registry)
 				buildContext := ffs.CreateBuildContext(fmt.Sprintf(`FROM %s
 		CMD ["echo", "bar"]
-			`, defaultImage))
+			`, localImages["defaultImage"]))
 				ginkgo.DeferCleanup(os.RemoveAll, buildContext)
 				command.Run(o, "build", "-t", tag, buildContext)
 			})

--- a/tests/logout.go
+++ b/tests/logout.go
@@ -54,7 +54,7 @@ func Logout(o *option.Option) {
 				tag = fmt.Sprintf(`%s/test-login:tag`, registry)
 				buildContext := ffs.CreateBuildContext(fmt.Sprintf(`FROM %s
 		CMD ["echo", "bar"]
-			`, localImages["defaultImage"]))
+			`, localImages[defaultImage]))
 				ginkgo.DeferCleanup(os.RemoveAll, buildContext)
 				command.Run(o, "build", "-t", tag, buildContext)
 			})

--- a/tests/logout.go
+++ b/tests/logout.go
@@ -54,7 +54,7 @@ func Logout(o *option.Option) {
 				tag = fmt.Sprintf(`%s/test-login:tag`, registry)
 				buildContext := ffs.CreateBuildContext(fmt.Sprintf(`FROM %s
 		CMD ["echo", "bar"]
-			`, defaultImage))
+			`, localImages["defaultImage"]))
 				ginkgo.DeferCleanup(os.RemoveAll, buildContext)
 				command.Run(o, "build", "-t", tag, buildContext)
 			})

--- a/tests/logs.go
+++ b/tests/logs.go
@@ -31,7 +31,7 @@ func Logs(o *option.Option) {
 			ginkgo.BeforeEach(func() {
 				// Currently, only containers created with `run -d` are supported.
 				// https://github.com/containerd/nerdctl#whale-nerdctl-logs
-				command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "echo", foo)
+				command.Run(o, "run", "-d", "--name", testContainerName, localImages[defaultImage], "echo", foo)
 			})
 
 			ginkgo.It("should fetch the logs of a container", func() {
@@ -71,7 +71,7 @@ func Logs(o *option.Option) {
 		ginkgo.When("the container is not running and has multiple lines of logs", func() {
 			const bar = "bar"
 			ginkgo.BeforeEach(func() {
-				command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"],
+				command.Run(o, "run", "-d", "--name", testContainerName, localImages[defaultImage],
 					"sh", "-c", fmt.Sprintf("echo %s; echo %s", foo, bar))
 			})
 
@@ -89,7 +89,7 @@ func Logs(o *option.Option) {
 
 		ginkgo.When("the container is running", func() {
 			ginkgo.BeforeEach(func() {
-				command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "sleep", "infinity")
+				command.Run(o, "run", "-d", "--name", testContainerName, localImages[defaultImage], "sleep", "infinity")
 			})
 
 			for _, follow := range []string{"-f", "--follow"} {

--- a/tests/logs.go
+++ b/tests/logs.go
@@ -31,7 +31,7 @@ func Logs(o *option.Option) {
 			ginkgo.BeforeEach(func() {
 				// Currently, only containers created with `run -d` are supported.
 				// https://github.com/containerd/nerdctl#whale-nerdctl-logs
-				command.Run(o, "run", "-d", "--name", testContainerName, defaultImage, "echo", foo)
+				command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "echo", foo)
 			})
 
 			ginkgo.It("should fetch the logs of a container", func() {
@@ -71,7 +71,7 @@ func Logs(o *option.Option) {
 		ginkgo.When("the container is not running and has multiple lines of logs", func() {
 			const bar = "bar"
 			ginkgo.BeforeEach(func() {
-				command.Run(o, "run", "-d", "--name", testContainerName, defaultImage,
+				command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"],
 					"sh", "-c", fmt.Sprintf("echo %s; echo %s", foo, bar))
 			})
 
@@ -89,7 +89,7 @@ func Logs(o *option.Option) {
 
 		ginkgo.When("the container is running", func() {
 			ginkgo.BeforeEach(func() {
-				command.Run(o, "run", "-d", "--name", testContainerName, defaultImage, "sleep", "infinity")
+				command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "sleep", "infinity")
 			})
 
 			for _, follow := range []string{"-f", "--follow"} {

--- a/tests/network_create.go
+++ b/tests/network_create.go
@@ -29,9 +29,9 @@ func NetworkCreate(o *option.Option) {
 		})
 
 		ginkgo.It("containers under the same network can communicate with each other", func() {
-			command.Run(o, "run", "-d", "--name", testContainerName, defaultImage, "sh", "-c", "echo hello | nc -l -p 80")
+			command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "sh", "-c", "echo hello | nc -l -p 80")
 			ipAddr := command.StdoutStr(o, "inspect", "--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", testContainerName)
-			output := command.StdoutStr(o, "run", defaultImage, "nc", fmt.Sprintf("%s:80", ipAddr))
+			output := command.StdoutStr(o, "run", localImages["defaultImage"], "nc", fmt.Sprintf("%s:80", ipAddr))
 			gomega.Expect(output).Should(gomega.Equal("hello"))
 		})
 
@@ -63,12 +63,12 @@ func NetworkCreate(o *option.Option) {
 			output := command.StdoutStr(o, "network", "inspect", testNetwork, "--format", "{{(index .IPAM.Config 0).IPRange}}")
 			gomega.Expect(output).Should(gomega.Equal(ipRange))
 
-			command.Run(o, "run", "-d", "--name", testContainerName, "--network", testNetwork, defaultImage, "sleep", "infinity")
+			command.Run(o, "run", "-d", "--name", testContainerName, "--network", testNetwork, localImages["defaultImage"], "sleep", "infinity")
 			ipAddr := command.StdoutStr(o, "inspect", testContainerName, "--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}")
 			// Must be 10.5.1.1 because there is only one IP in the IP range.
 			gomega.Expect(ipAddr).Should(gomega.Equal("10.5.1.1"))
 			// Must fail because there is no available IP in the IP range now.
-			command.RunWithoutSuccessfulExit(o, "run", "--name", "test-ctr2", "--network", testNetwork, defaultImage)
+			command.RunWithoutSuccessfulExit(o, "run", "--name", "test-ctr2", "--network", testNetwork, localImages["defaultImage"])
 		})
 
 		ginkgo.It("should create a network with label using --label flag", func() {

--- a/tests/network_create.go
+++ b/tests/network_create.go
@@ -29,9 +29,9 @@ func NetworkCreate(o *option.Option) {
 		})
 
 		ginkgo.It("containers under the same network can communicate with each other", func() {
-			command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "sh", "-c", "echo hello | nc -l -p 80")
+			command.Run(o, "run", "-d", "--name", testContainerName, localImages[defaultImage], "sh", "-c", "echo hello | nc -l -p 80")
 			ipAddr := command.StdoutStr(o, "inspect", "--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", testContainerName)
-			output := command.StdoutStr(o, "run", localImages["defaultImage"], "nc", fmt.Sprintf("%s:80", ipAddr))
+			output := command.StdoutStr(o, "run", localImages[defaultImage], "nc", fmt.Sprintf("%s:80", ipAddr))
 			gomega.Expect(output).Should(gomega.Equal("hello"))
 		})
 
@@ -63,12 +63,12 @@ func NetworkCreate(o *option.Option) {
 			output := command.StdoutStr(o, "network", "inspect", testNetwork, "--format", "{{(index .IPAM.Config 0).IPRange}}")
 			gomega.Expect(output).Should(gomega.Equal(ipRange))
 
-			command.Run(o, "run", "-d", "--name", testContainerName, "--network", testNetwork, localImages["defaultImage"], "sleep", "infinity")
+			command.Run(o, "run", "-d", "--name", testContainerName, "--network", testNetwork, localImages[defaultImage], "sleep", "infinity")
 			ipAddr := command.StdoutStr(o, "inspect", testContainerName, "--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}")
 			// Must be 10.5.1.1 because there is only one IP in the IP range.
 			gomega.Expect(ipAddr).Should(gomega.Equal("10.5.1.1"))
 			// Must fail because there is no available IP in the IP range now.
-			command.RunWithoutSuccessfulExit(o, "run", "--name", "test-ctr2", "--network", testNetwork, localImages["defaultImage"])
+			command.RunWithoutSuccessfulExit(o, "run", "--name", "test-ctr2", "--network", testNetwork, localImages[defaultImage])
 		})
 
 		ginkgo.It("should create a network with label using --label flag", func() {

--- a/tests/port.go
+++ b/tests/port.go
@@ -27,7 +27,7 @@ func Port(o *option.Option) {
 
 		ginkgo.It("should output port mappings for a container", func() {
 			hostPort := fnet.GetFreePort()
-			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d", hostPort, containerPort), "--name", testContainerName, defaultImage)
+			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d", hostPort, containerPort), "--name", testContainerName, localImages["defaultImage"])
 
 			output := command.StdoutStr(o, "port", testContainerName)
 			gomega.Expect(output).Should(gomega.Equal(fmt.Sprintf("%d/tcp -> 0.0.0.0:%d", containerPort, hostPort)))
@@ -35,7 +35,7 @@ func Port(o *option.Option) {
 
 		ginkgo.It("should output the host port according to container port", func() {
 			hostPort := fnet.GetFreePort()
-			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d", hostPort, containerPort), "--name", testContainerName, defaultImage)
+			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d", hostPort, containerPort), "--name", testContainerName, localImages["defaultImage"])
 
 			output := command.StdoutStr(o, "port", testContainerName, fmt.Sprintf("%d/tcp", containerPort))
 			gomega.Expect(output).Should(gomega.Equal(fmt.Sprintf("0.0.0.0:%d", hostPort)))
@@ -43,14 +43,14 @@ func Port(o *option.Option) {
 
 		ginkgo.It("should have error if specifying wrong protocol", func() {
 			hostPort := fnet.GetFreePort()
-			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d/udp", hostPort, containerPort), "--name", testContainerName, defaultImage)
+			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d/udp", hostPort, containerPort), "--name", testContainerName, localImages["defaultImage"])
 
 			command.RunWithoutSuccessfulExit(o, "port", testContainerName, fmt.Sprintf("%d/tcp", containerPort))
 		})
 
 		ginkgo.It("should still output the host port according to container port when no protocol is specified", func() {
 			hostPort := fnet.GetFreePort()
-			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d", hostPort, containerPort), "--name", testContainerName, defaultImage)
+			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d", hostPort, containerPort), "--name", testContainerName, localImages["defaultImage"])
 
 			output := command.StdoutStr(o, "port", testContainerName, fmt.Sprint(containerPort))
 			gomega.Expect(output).Should(gomega.Equal(fmt.Sprintf("0.0.0.0:%d", hostPort)))
@@ -58,7 +58,7 @@ func Port(o *option.Option) {
 
 		ginkgo.It("should have error if trying to print container port which is not published to any host port", func() {
 			hostPort := fnet.GetFreePort()
-			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d", hostPort, containerPort), "--name", testContainerName, defaultImage)
+			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d", hostPort, containerPort), "--name", testContainerName, localImages["defaultImage"])
 
 			command.RunWithoutSuccessfulExit(o, "port", testContainerName, "111/tcp")
 		})

--- a/tests/port.go
+++ b/tests/port.go
@@ -27,7 +27,7 @@ func Port(o *option.Option) {
 
 		ginkgo.It("should output port mappings for a container", func() {
 			hostPort := fnet.GetFreePort()
-			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d", hostPort, containerPort), "--name", testContainerName, localImages["defaultImage"])
+			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d", hostPort, containerPort), "--name", testContainerName, localImages[defaultImage])
 
 			output := command.StdoutStr(o, "port", testContainerName)
 			gomega.Expect(output).Should(gomega.Equal(fmt.Sprintf("%d/tcp -> 0.0.0.0:%d", containerPort, hostPort)))
@@ -35,7 +35,7 @@ func Port(o *option.Option) {
 
 		ginkgo.It("should output the host port according to container port", func() {
 			hostPort := fnet.GetFreePort()
-			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d", hostPort, containerPort), "--name", testContainerName, localImages["defaultImage"])
+			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d", hostPort, containerPort), "--name", testContainerName, localImages[defaultImage])
 
 			output := command.StdoutStr(o, "port", testContainerName, fmt.Sprintf("%d/tcp", containerPort))
 			gomega.Expect(output).Should(gomega.Equal(fmt.Sprintf("0.0.0.0:%d", hostPort)))
@@ -43,14 +43,21 @@ func Port(o *option.Option) {
 
 		ginkgo.It("should have error if specifying wrong protocol", func() {
 			hostPort := fnet.GetFreePort()
-			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d/udp", hostPort, containerPort), "--name", testContainerName, localImages["defaultImage"])
+			command.Run(o,
+				"run",
+				"-p",
+				fmt.Sprintf("%d:%d/udp", hostPort, containerPort),
+				"--name",
+				testContainerName,
+				localImages[defaultImage],
+			)
 
 			command.RunWithoutSuccessfulExit(o, "port", testContainerName, fmt.Sprintf("%d/tcp", containerPort))
 		})
 
 		ginkgo.It("should still output the host port according to container port when no protocol is specified", func() {
 			hostPort := fnet.GetFreePort()
-			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d", hostPort, containerPort), "--name", testContainerName, localImages["defaultImage"])
+			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d", hostPort, containerPort), "--name", testContainerName, localImages[defaultImage])
 
 			output := command.StdoutStr(o, "port", testContainerName, fmt.Sprint(containerPort))
 			gomega.Expect(output).Should(gomega.Equal(fmt.Sprintf("0.0.0.0:%d", hostPort)))
@@ -58,7 +65,7 @@ func Port(o *option.Option) {
 
 		ginkgo.It("should have error if trying to print container port which is not published to any host port", func() {
 			hostPort := fnet.GetFreePort()
-			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d", hostPort, containerPort), "--name", testContainerName, localImages["defaultImage"])
+			command.Run(o, "run", "-p", fmt.Sprintf("%d:%d", hostPort, containerPort), "--name", testContainerName, localImages[defaultImage])
 
 			command.RunWithoutSuccessfulExit(o, "port", testContainerName, "111/tcp")
 		})

--- a/tests/ps.go
+++ b/tests/ps.go
@@ -25,10 +25,10 @@ func Ps(o *option.Option) {
 			command.Run(o, "network", "create", testNetwork)
 			command.Run(o, "run", "-d",
 				"--name", containerNames[0],
-				localImages["defaultImage"])
+				localImages[defaultImage])
 			command.Run(o, "run", "-d",
 				"--name", containerNames[1],
-				localImages["defaultImage"], "sleep", "infinity")
+				localImages[defaultImage], "sleep", "infinity")
 		})
 
 		ginkgo.AfterEach(func() {
@@ -54,7 +54,7 @@ func Ps(o *option.Option) {
 		})
 		ginkgo.It("should list image of the containers", func() {
 			psOutput := command.StdoutAsLines(o, "ps", "--format", "{{.Image}}")
-			gomega.Expect(psOutput).Should(gomega.ContainElement(localImages["defaultImage"]))
+			gomega.Expect(psOutput).Should(gomega.ContainElement(localImages[defaultImage]))
 		})
 		ginkgo.It("should list command of the containers", func() {
 			psOutput := command.StdoutStr(o, "ps", "--format", "{{.Command}}")
@@ -121,13 +121,13 @@ func Ps(o *option.Option) {
 				"--label", "color=red",
 				"-v", fmt.Sprintf("%s:%s", pwd, pwd),
 				"-w", pwd,
-				localImages["defaultImage"])
+				localImages[defaultImage])
 			command.Run(o, "run", "-d",
 				"--label", "color=green",
 				"--network", testNetwork,
 				"-p", "8081:80",
 				"--name", containerNames[1],
-				localImages["defaultImage"], "sleep", "infinity")
+				localImages[defaultImage], "sleep", "infinity")
 		})
 
 		ginkgo.AfterEach(func() {
@@ -149,13 +149,13 @@ func Ps(o *option.Option) {
 				"--label", "color=red",
 				"-v", fmt.Sprintf("%s:%s", pwd, pwd),
 				"-w", pwd,
-				localImages["defaultImage"])
+				localImages[defaultImage])
 			command.Run(o, "run", "-d",
 				"--label", "color=green",
 				"--network", testNetwork,
 				"-p", "8081:80",
 				"--name", containerNames[1],
-				localImages["defaultImage"], "sleep", "infinity")
+				localImages[defaultImage], "sleep", "infinity")
 		})
 
 		ginkgo.AfterEach(func() {

--- a/tests/ps.go
+++ b/tests/ps.go
@@ -25,10 +25,10 @@ func Ps(o *option.Option) {
 			command.Run(o, "network", "create", testNetwork)
 			command.Run(o, "run", "-d",
 				"--name", containerNames[0],
-				defaultImage)
+				localImages["defaultImage"])
 			command.Run(o, "run", "-d",
 				"--name", containerNames[1],
-				defaultImage, "sleep", "infinity")
+				localImages["defaultImage"], "sleep", "infinity")
 		})
 
 		ginkgo.AfterEach(func() {
@@ -54,7 +54,7 @@ func Ps(o *option.Option) {
 		})
 		ginkgo.It("should list image of the containers", func() {
 			psOutput := command.StdoutAsLines(o, "ps", "--format", "{{.Image}}")
-			gomega.Expect(psOutput).Should(gomega.ContainElement(defaultImage))
+			gomega.Expect(psOutput).Should(gomega.ContainElement(localImages["defaultImage"]))
 		})
 		ginkgo.It("should list command of the containers", func() {
 			psOutput := command.StdoutStr(o, "ps", "--format", "{{.Command}}")
@@ -121,13 +121,13 @@ func Ps(o *option.Option) {
 				"--label", "color=red",
 				"-v", fmt.Sprintf("%s:%s", pwd, pwd),
 				"-w", pwd,
-				defaultImage)
+				localImages["defaultImage"])
 			command.Run(o, "run", "-d",
 				"--label", "color=green",
 				"--network", testNetwork,
 				"-p", "8081:80",
 				"--name", containerNames[1],
-				defaultImage, "sleep", "infinity")
+				localImages["defaultImage"], "sleep", "infinity")
 		})
 
 		ginkgo.AfterEach(func() {
@@ -149,13 +149,13 @@ func Ps(o *option.Option) {
 				"--label", "color=red",
 				"-v", fmt.Sprintf("%s:%s", pwd, pwd),
 				"-w", pwd,
-				defaultImage)
+				localImages["defaultImage"])
 			command.Run(o, "run", "-d",
 				"--label", "color=green",
 				"--network", testNetwork,
 				"-p", "8081:80",
 				"--name", containerNames[1],
-				defaultImage, "sleep", "infinity")
+				localImages["defaultImage"], "sleep", "infinity")
 		})
 
 		ginkgo.AfterEach(func() {

--- a/tests/pull.go
+++ b/tests/pull.go
@@ -22,8 +22,8 @@ func Pull(o *option.Option) {
 		})
 
 		ginkgo.It("should pull the default image successfully", func() {
-			command.Run(o, "pull", defaultImage)
-			imageShouldExist(o, defaultImage)
+			command.Run(o, "pull", localImages["defaultImage"])
+			imageShouldExist(o, localImages["defaultImage"])
 		})
 	})
 }

--- a/tests/pull.go
+++ b/tests/pull.go
@@ -22,8 +22,8 @@ func Pull(o *option.Option) {
 		})
 
 		ginkgo.It("should pull the default image successfully", func() {
-			command.Run(o, "pull", localImages["defaultImage"])
-			imageShouldExist(o, localImages["defaultImage"])
+			command.Run(o, "pull", localImages[defaultImage])
+			imageShouldExist(o, localImages[defaultImage])
 		})
 	})
 }

--- a/tests/push.go
+++ b/tests/push.go
@@ -26,7 +26,7 @@ func Push(o *option.Option) {
 			command.RemoveAll(o)
 			buildContext = ffs.CreateBuildContext(fmt.Sprintf(`FROM %s
 		CMD ["echo", "bar"]
-			`, localImages["defaultImage"]))
+			`, localImages[defaultImage]))
 			ginkgo.DeferCleanup(os.RemoveAll, buildContext)
 			port = fnet.GetFreePort()
 			command.Run(o, "run", "-dp", fmt.Sprintf("%d:5000", port), "--name", "registry", registryImage)

--- a/tests/push.go
+++ b/tests/push.go
@@ -26,7 +26,7 @@ func Push(o *option.Option) {
 			command.RemoveAll(o)
 			buildContext = ffs.CreateBuildContext(fmt.Sprintf(`FROM %s
 		CMD ["echo", "bar"]
-			`, defaultImage))
+			`, localImages["defaultImage"]))
 			ginkgo.DeferCleanup(os.RemoveAll, buildContext)
 			port = fnet.GetFreePort()
 			command.Run(o, "run", "-dp", fmt.Sprintf("%d:5000", port), "--name", "registry", registryImage)

--- a/tests/restart.go
+++ b/tests/restart.go
@@ -24,7 +24,7 @@ func Restart(o *option.Option) {
 			// which means that we'll have to wait for the default timeout (10 seconds for now) to restart the container,
 			// so we use `nc -l` instead to save time.
 			// TODO: Remove the above comment after we add a test case for -t/--time flag with `sleep infinity` because it's more obvious.
-			command.Run(o, "run", "-d", "--name", testContainerName, defaultImage, "nc", "-l")
+			command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "nc", "-l")
 		})
 
 		ginkgo.AfterEach(func() {
@@ -41,7 +41,7 @@ func Restart(o *option.Option) {
 
 		ginkgo.It("should restart multiple running containers", func() {
 			const ctrName = "ctr-name"
-			command.Run(o, "run", "-d", "--name", ctrName, defaultImage, "nc", "-l")
+			command.Run(o, "run", "-d", "--name", ctrName, localImages["defaultImage"], "nc", "-l")
 			pid := getContainerPID(o, testContainerName)
 			pid2 := getContainerPID(o, ctrName)
 			command.Run(o, "restart", testContainerName, ctrName)

--- a/tests/restart.go
+++ b/tests/restart.go
@@ -24,7 +24,7 @@ func Restart(o *option.Option) {
 			// which means that we'll have to wait for the default timeout (10 seconds for now) to restart the container,
 			// so we use `nc -l` instead to save time.
 			// TODO: Remove the above comment after we add a test case for -t/--time flag with `sleep infinity` because it's more obvious.
-			command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "nc", "-l")
+			command.Run(o, "run", "-d", "--name", testContainerName, localImages[defaultImage], "nc", "-l")
 		})
 
 		ginkgo.AfterEach(func() {
@@ -41,7 +41,7 @@ func Restart(o *option.Option) {
 
 		ginkgo.It("should restart multiple running containers", func() {
 			const ctrName = "ctr-name"
-			command.Run(o, "run", "-d", "--name", ctrName, localImages["defaultImage"], "nc", "-l")
+			command.Run(o, "run", "-d", "--name", ctrName, localImages[defaultImage], "nc", "-l")
 			pid := getContainerPID(o, testContainerName)
 			pid2 := getContainerPID(o, ctrName)
 			command.Run(o, "restart", testContainerName, ctrName)

--- a/tests/rm.go
+++ b/tests/rm.go
@@ -24,7 +24,7 @@ func Rm(o *option.Option) {
 		})
 
 		ginkgo.It("should remove the container when it is not running", func() {
-			command.Run(o, "run", "--name", testContainerName, defaultImage)
+			command.Run(o, "run", "--name", testContainerName, localImages["defaultImage"])
 			containerShouldExist(o, testContainerName)
 
 			command.Run(o, "rm", testContainerName)
@@ -34,7 +34,7 @@ func Rm(o *option.Option) {
 
 		ginkgo.Context("when the container is running", func() {
 			ginkgo.BeforeEach(func() {
-				command.Run(o, "run", "-d", "--name", testContainerName, defaultImage, "sleep", "infinity")
+				command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "sleep", "infinity")
 			})
 
 			ginkgo.It("should not be able to remove the container without -f/--force flag", func() {
@@ -57,7 +57,7 @@ func Rm(o *option.Option) {
 				volumes := volumes
 				ginkgo.It(fmt.Sprintf("with %s flag, should remove the container and the anonymous volume used by the container", volumes),
 					func() {
-						command.Run(o, "run", "-v", "/usr/share", "--name", testContainerName, defaultImage)
+						command.Run(o, "run", "-v", "/usr/share", "--name", testContainerName, localImages["defaultImage"])
 						anonymousVolume := command.StdoutStr(o, "inspect", testContainerName,
 							"--format", "{{range .Mounts}}{{.Name}}{{end}}")
 						containerShouldExist(o, testContainerName)
@@ -71,7 +71,7 @@ func Rm(o *option.Option) {
 
 				ginkgo.It(fmt.Sprintf("with %s flag, should remove the container but can't remove the named volume used by container", volumes),
 					func() {
-						command.Run(o, "run", "-v", "foo:/usr/share", "--name", testContainerName, defaultImage)
+						command.Run(o, "run", "-v", "foo:/usr/share", "--name", testContainerName, localImages["defaultImage"])
 						volumeShouldExist(o, "foo")
 
 						command.Run(o, "rm", volumes, testContainerName)

--- a/tests/rm.go
+++ b/tests/rm.go
@@ -24,7 +24,7 @@ func Rm(o *option.Option) {
 		})
 
 		ginkgo.It("should remove the container when it is not running", func() {
-			command.Run(o, "run", "--name", testContainerName, localImages["defaultImage"])
+			command.Run(o, "run", "--name", testContainerName, localImages[defaultImage])
 			containerShouldExist(o, testContainerName)
 
 			command.Run(o, "rm", testContainerName)
@@ -34,7 +34,7 @@ func Rm(o *option.Option) {
 
 		ginkgo.Context("when the container is running", func() {
 			ginkgo.BeforeEach(func() {
-				command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "sleep", "infinity")
+				command.Run(o, "run", "-d", "--name", testContainerName, localImages[defaultImage], "sleep", "infinity")
 			})
 
 			ginkgo.It("should not be able to remove the container without -f/--force flag", func() {
@@ -57,7 +57,7 @@ func Rm(o *option.Option) {
 				volumes := volumes
 				ginkgo.It(fmt.Sprintf("with %s flag, should remove the container and the anonymous volume used by the container", volumes),
 					func() {
-						command.Run(o, "run", "-v", "/usr/share", "--name", testContainerName, localImages["defaultImage"])
+						command.Run(o, "run", "-v", "/usr/share", "--name", testContainerName, localImages[defaultImage])
 						anonymousVolume := command.StdoutStr(o, "inspect", testContainerName,
 							"--format", "{{range .Mounts}}{{.Name}}{{end}}")
 						containerShouldExist(o, testContainerName)
@@ -71,7 +71,7 @@ func Rm(o *option.Option) {
 
 				ginkgo.It(fmt.Sprintf("with %s flag, should remove the container but can't remove the named volume used by container", volumes),
 					func() {
-						command.Run(o, "run", "-v", "foo:/usr/share", "--name", testContainerName, localImages["defaultImage"])
+						command.Run(o, "run", "-v", "foo:/usr/share", "--name", testContainerName, localImages[defaultImage])
 						volumeShouldExist(o, "foo")
 
 						command.Run(o, "rm", volumes, testContainerName)

--- a/tests/rmi.go
+++ b/tests/rmi.go
@@ -23,28 +23,28 @@ func Rmi(o *option.Option) {
 		})
 
 		ginkgo.It("should remove an image when container is not running", func() {
-			pullImage(o, localImages["defaultImage"])
+			pullImage(o, localImages[defaultImage])
 
-			command.Run(o, "rmi", localImages["defaultImage"])
-			imageShouldNotExist(o, localImages["defaultImage"])
+			command.Run(o, "rmi", localImages[defaultImage])
+			imageShouldNotExist(o, localImages[defaultImage])
 		})
 
 		ginkgo.Context("when there is a container based on the image to be removed", func() {
 			ginkgo.BeforeEach(func() {
-				pullImage(o, localImages["defaultImage"])
-				command.Run(o, "run", localImages["defaultImage"])
+				pullImage(o, localImages[defaultImage])
+				command.Run(o, "run", localImages[defaultImage])
 			})
 
 			ginkgo.It("should not be able to remove the image without -f/--force flag", func() {
-				command.RunWithoutSuccessfulExit(o, "rmi", localImages["defaultImage"])
-				imageShouldExist(o, localImages["defaultImage"])
+				command.RunWithoutSuccessfulExit(o, "rmi", localImages[defaultImage])
+				imageShouldExist(o, localImages[defaultImage])
 			})
 
 			for _, force := range []string{"-f", "--force"} {
 				force := force
 				ginkgo.It(fmt.Sprintf("should be able to remove the image with %s flag", force), func() {
-					command.Run(o, "rmi", force, localImages["defaultImage"])
-					imageShouldNotExist(o, localImages["defaultImage"])
+					command.Run(o, "rmi", force, localImages[defaultImage])
+					imageShouldNotExist(o, localImages[defaultImage])
 				})
 			}
 		})

--- a/tests/rmi.go
+++ b/tests/rmi.go
@@ -23,28 +23,28 @@ func Rmi(o *option.Option) {
 		})
 
 		ginkgo.It("should remove an image when container is not running", func() {
-			pullImage(o, defaultImage)
+			pullImage(o, localImages["defaultImage"])
 
-			command.Run(o, "rmi", defaultImage)
-			imageShouldNotExist(o, defaultImage)
+			command.Run(o, "rmi", localImages["defaultImage"])
+			imageShouldNotExist(o, localImages["defaultImage"])
 		})
 
 		ginkgo.Context("when there is a container based on the image to be removed", func() {
 			ginkgo.BeforeEach(func() {
-				pullImage(o, defaultImage)
-				command.Run(o, "run", defaultImage)
+				pullImage(o, localImages["defaultImage"])
+				command.Run(o, "run", localImages["defaultImage"])
 			})
 
 			ginkgo.It("should not be able to remove the image without -f/--force flag", func() {
-				command.RunWithoutSuccessfulExit(o, "rmi", defaultImage)
-				imageShouldExist(o, defaultImage)
+				command.RunWithoutSuccessfulExit(o, "rmi", localImages["defaultImage"])
+				imageShouldExist(o, localImages["defaultImage"])
 			})
 
 			for _, force := range []string{"-f", "--force"} {
 				force := force
 				ginkgo.It(fmt.Sprintf("should be able to remove the image with %s flag", force), func() {
-					command.Run(o, "rmi", force, defaultImage)
-					imageShouldNotExist(o, defaultImage)
+					command.Run(o, "rmi", force, localImages["defaultImage"])
+					imageShouldNotExist(o, localImages["defaultImage"])
 				})
 			}
 		})

--- a/tests/run.go
+++ b/tests/run.go
@@ -50,7 +50,7 @@ func Run(o *RunOption) {
 			ginkgo.BeforeEach(func() {
 				dockerfile := fmt.Sprintf(`FROM %s
 			CMD ["echo", "finch-test-dummy-output"]
-			`, localImages["defaultImage"])
+			`, localImages[defaultImage])
 				buildContext := ffs.CreateBuildContext(dockerfile)
 				ginkgo.DeferCleanup(os.RemoveAll, buildContext)
 				command.Run(o.BaseOpt, "build", "-q", "-t", testImageName, buildContext)
@@ -68,7 +68,7 @@ func Run(o *RunOption) {
 		})
 
 		ginkgo.It("with --rm flag, container should be removed when it exits", func() {
-			command.Run(o.BaseOpt, "run", "--rm", "--name", testContainerName, localImages["defaultImage"])
+			command.Run(o.BaseOpt, "run", "--rm", "--name", testContainerName, localImages[defaultImage])
 			err := containerShouldNotExist(o.BaseOpt, testContainerName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
@@ -77,7 +77,7 @@ func Run(o *RunOption) {
 			for _, label := range []string{"-l", "--label"} {
 				label := label
 				ginkgo.It(fmt.Sprintf("should set meta data on a container with %s flag", label), func() {
-					command.Run(o.BaseOpt, "run", "--name", testContainerName, label, "testKey=testValue", localImages["defaultImage"])
+					command.Run(o.BaseOpt, "run", "--name", testContainerName, label, "testKey=testValue", localImages[defaultImage])
 					gomega.Expect(command.StdoutStr(o.BaseOpt, "inspect", testContainerName,
 						"--format", "{{.Config.Labels.testKey}}")).To(gomega.Equal("testValue"))
 				})
@@ -87,7 +87,7 @@ func Run(o *RunOption) {
 				dir := ffs.CreateTempDir("finch-test-cid")
 				ginkgo.DeferCleanup(os.RemoveAll, dir)
 				path := filepath.Join(dir, "test.cid")
-				containerID := command.StdoutStr(o.BaseOpt, "run", "-d", "--cidfile", path, localImages["defaultImage"])
+				containerID := command.StdoutStr(o.BaseOpt, "run", "-d", "--cidfile", path, localImages[defaultImage])
 				output, err := os.ReadFile(filepath.Clean(path))
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				gomega.Expect(strings.TrimSpace(string(output))).Should(gomega.Equal(containerID))
@@ -96,7 +96,7 @@ func Run(o *RunOption) {
 			ginkgo.It("should read labels from file with --label-file flag", func() {
 				path := ffs.CreateTempFile("label-file", "key=value")
 				ginkgo.DeferCleanup(os.RemoveAll, filepath.Dir(path))
-				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--label-file", path, localImages["defaultImage"])
+				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--label-file", path, localImages[defaultImage])
 				gomega.Expect(command.StdoutStr(o.BaseOpt, "inspect", testContainerName,
 					"--format", "{{.Config.Labels.key}}")).To(gomega.Equal("value"))
 			})
@@ -107,7 +107,7 @@ func Run(o *RunOption) {
 				dockerfile := fmt.Sprintf(`FROM %s
 		ENTRYPOINT ["echo", "foo"]
 		CMD ["echo", "bar"]
-			`, localImages["defaultImage"])
+			`, localImages[defaultImage])
 				buildContext := ffs.CreateBuildContext(dockerfile)
 				defer func() {
 					gomega.Expect(os.RemoveAll(buildContext)).To(gomega.Succeed())
@@ -124,7 +124,16 @@ func Run(o *RunOption) {
 				workDir := workDir
 				ginkgo.It(fmt.Sprintf("should set working directory inside the container specified by %s flag", workDir), func() {
 					dir := "/tmp"
-					gomega.Expect(command.StdoutStr(o.BaseOpt, "run", workDir, dir, localImages["defaultImage"], "pwd")).Should(gomega.Equal(dir))
+					gomega.Expect(
+						command.StdoutStr(
+							o.BaseOpt,
+							"run",
+							workDir,
+							dir,
+							localImages[defaultImage],
+							"pwd",
+						),
+					).Should(gomega.Equal(dir))
 				})
 			}
 
@@ -133,7 +142,7 @@ func Run(o *RunOption) {
 				ginkgo.It(fmt.Sprintf("with %s flag, environment variables should be set in the container", env), func() {
 					envOutput := command.Stdout(o.BaseOpt, "run", "--rm",
 						env, "FOO=BAR", env, "FOO1", env, "ENV1=1", env, "ENV1=2",
-						localImages["defaultImage"], "env")
+						localImages[defaultImage], "env")
 					gomega.Expect(envOutput).To(gomega.ContainSubstring("FOO=BAR"))
 					gomega.Expect(envOutput).ToNot(gomega.ContainSubstring("FOO1"))
 					gomega.Expect(envOutput).To(gomega.ContainSubstring("ENV1=2"))
@@ -143,7 +152,7 @@ func Run(o *RunOption) {
 			ginkgo.It("with -e flag passing env variables without a value, only host set vars should be set in the container", func() {
 				gomega.Expect(os.Setenv("AVAR1", "avalue")).To(gomega.Succeed())
 				envOutput := command.Stdout(o.BaseOpt, "run", "--rm",
-					"-e", "AVAR1", "-e", "AVAR2", localImages["defaultImage"], "env")
+					"-e", "AVAR1", "-e", "AVAR2", localImages[defaultImage], "env")
 				gomega.Expect(envOutput).To(gomega.ContainSubstring("AVAR1=avalue"))
 				gomega.Expect(envOutput).ToNot(gomega.ContainSubstring("AVAR2"))
 			})
@@ -153,7 +162,7 @@ func Run(o *RunOption) {
 				envPath := ffs.CreateTempFile("env", envPair)
 				ginkgo.DeferCleanup(os.RemoveAll, filepath.Dir(envPath))
 
-				envOutput := command.Stdout(o.BaseOpt, "run", "--rm", "--env-file", envPath, localImages["defaultImage"], "env")
+				envOutput := command.Stdout(o.BaseOpt, "run", "--rm", "--env-file", envPath, localImages[defaultImage], "env")
 				gomega.Expect(envOutput).To(gomega.ContainSubstring(envPair))
 			})
 
@@ -162,7 +171,7 @@ func Run(o *RunOption) {
 				envPath := ffs.CreateTempFile("env", envPair)
 				ginkgo.DeferCleanup(os.RemoveAll, filepath.Dir(envPath))
 				gomega.Expect(os.Setenv("AVAR1", "avalue")).To(gomega.Succeed())
-				envOutput := command.Stdout(o.BaseOpt, "run", "--rm", "--env-file", envPath, localImages["defaultImage"], "env")
+				envOutput := command.Stdout(o.BaseOpt, "run", "--rm", "--env-file", envPath, localImages[defaultImage], "env")
 				gomega.Expect(envOutput).To(gomega.ContainSubstring("ENVKEY=ENVVAL"))
 				gomega.Expect(envOutput).To(gomega.ContainSubstring("AVAR1=avalue"))
 				gomega.Expect(envOutput).ToNot(gomega.ContainSubstring("AVAR2"))
@@ -173,7 +182,7 @@ func Run(o *RunOption) {
 				envPath := ffs.CreateTempFile("env", envPair)
 				ginkgo.DeferCleanup(os.RemoveAll, filepath.Dir(envPath))
 				gomega.Expect(os.Setenv("AVAR1", "avalue")).To(gomega.Succeed())
-				envOutput := command.Stdout(o.BaseOpt, "run", "--rm", "--env-file", envPath, localImages["defaultImage"], "env")
+				envOutput := command.Stdout(o.BaseOpt, "run", "--rm", "--env-file", envPath, localImages[defaultImage], "env")
 				gomega.Expect(envOutput).To(gomega.ContainSubstring("ENVKEY=ENVVAL"))
 				gomega.Expect(envOutput).To(gomega.ContainSubstring("AVAR1=avalue"))
 				gomega.Expect(envOutput).ToNot(gomega.ContainSubstring("AVAR2"))
@@ -182,37 +191,37 @@ func Run(o *RunOption) {
 
 		ginkgo.When("running an image with --pull flag", func() {
 			ginkgo.It("should have an error if set --pull=never and the image doesn't exist", func() {
-				command.RunWithoutSuccessfulExit(o.BaseOpt, "run", "--pull", "never", localImages["defaultImage"])
-				imageShouldNotExist(o.BaseOpt, localImages["defaultImage"])
+				command.RunWithoutSuccessfulExit(o.BaseOpt, "run", "--pull", "never", localImages[defaultImage])
+				imageShouldNotExist(o.BaseOpt, localImages[defaultImage])
 			})
 
 			ginkgo.It("should be able to run the container if set --pull=never and the image exists", func() {
 				const containerName = "test-container"
-				pullImage(o.BaseOpt, localImages["defaultImage"])
-				command.Run(o.BaseOpt, "run", "--name", containerName, "--pull", "never", localImages["defaultImage"])
+				pullImage(o.BaseOpt, localImages[defaultImage])
+				command.Run(o.BaseOpt, "run", "--name", containerName, "--pull", "never", localImages[defaultImage])
 				containerShouldExist(o.BaseOpt, containerName)
 			})
 
 			ginkgo.It("should be able to run the container if set --pull=missing and the image doesn't exist", func() {
-				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--pull", "missing", localImages["defaultImage"])
+				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--pull", "missing", localImages[defaultImage])
 				containerShouldExist(o.BaseOpt, testContainerName)
-				imageShouldExist(o.BaseOpt, localImages["defaultImage"])
+				imageShouldExist(o.BaseOpt, localImages[defaultImage])
 			})
 
 			ginkgo.It("should be able to run the container if set --pull=missing and the image exists", func() {
-				pullImage(o.BaseOpt, localImages["defaultImage"])
-				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--pull", "missing", localImages["defaultImage"])
+				pullImage(o.BaseOpt, localImages[defaultImage])
+				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--pull", "missing", localImages[defaultImage])
 				containerShouldExist(o.BaseOpt, testContainerName)
 			})
 
 			ginkgo.It("should be able to run the container if set --pull=always and the image doesn't exist", func() {
-				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--pull", "always", localImages["defaultImage"])
+				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--pull", "always", localImages[defaultImage])
 				containerShouldExist(o.BaseOpt, testContainerName)
-				imageShouldExist(o.BaseOpt, localImages["defaultImage"])
+				imageShouldExist(o.BaseOpt, localImages[defaultImage])
 			})
 			ginkgo.It("should be able to run the container if set --pull=always and the image exists", func() {
-				pullImage(o.BaseOpt, localImages["defaultImage"])
-				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--pull", "always", localImages["defaultImage"])
+				pullImage(o.BaseOpt, localImages[defaultImage])
+				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--pull", "always", localImages[defaultImage])
 			})
 		})
 
@@ -220,7 +229,7 @@ func Run(o *RunOption) {
 			interactive := interactive
 			ginkgo.It(fmt.Sprintf("should output string if %s flag keeps STDIN open", interactive), func() {
 				want := []byte("hello")
-				got := command.New(o.BaseOpt, "run", interactive, localImages["defaultImage"], "cat").
+				got := command.New(o.BaseOpt, "run", interactive, localImages[defaultImage], "cat").
 					WithStdin(gbytes.BufferWithBytes(want)).Run().Out.Contents()
 				gomega.Expect(got).Should(gomega.Equal(want))
 			})
@@ -229,7 +238,18 @@ func Run(o *RunOption) {
 		ginkgo.It("should stop running container within specified time by --stop-timeout flag", func() {
 			// With PID=1, `sleep infinity` does not exit due to receiving a SIGTERM, which is sent by the stop command.
 			// Ref. https://superuser.com/a/1299463/730265
-			command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, "--stop-timeout", "1", localImages["defaultImage"], "sleep", "infinity")
+			command.Run(
+				o.BaseOpt,
+				"run",
+				"-d",
+				"--name",
+				testContainerName,
+				"--stop-timeout",
+				"1",
+				localImages[defaultImage],
+				"sleep",
+				"infinity",
+			)
 			gomega.Expect(command.StdoutStr(o.BaseOpt, "exec", testContainerName, "echo", "foo")).To(gomega.Equal("foo"))
 			startTime := time.Now()
 			command.Run(o.BaseOpt, "stop", testContainerName)
@@ -240,7 +260,18 @@ func Run(o *RunOption) {
 
 		ginkgo.It("should immediately stop the container with --stop-signal=SIGKILL", func() {
 			// With PID=1, `sleep infinity` will only exit when receiving SIGKILL, while the signal sent by stop command is SIGTERM.
-			command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, "--stop-signal", "SIGKILL", localImages["defaultImage"], "sleep", "infinity")
+			command.Run(
+				o.BaseOpt,
+				"run",
+				"-d",
+				"--name",
+				testContainerName,
+				"--stop-signal",
+				"SIGKILL",
+				localImages[defaultImage],
+				"sleep",
+				"infinity",
+			)
 			containerShouldBeRunning(o.BaseOpt, testContainerName)
 			startTime := time.Now()
 			command.Run(o.BaseOpt, "stop", testContainerName)
@@ -251,13 +282,13 @@ func Run(o *RunOption) {
 		})
 
 		ginkgo.It("should share PID namespace with host with --pid=host", func() {
-			command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, "--pid=host", localImages["defaultImage"], "sleep", "infinity")
+			command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, "--pid=host", localImages[defaultImage], "sleep", "infinity")
 			pid := command.StdoutStr(o.BaseOpt, "inspect", "--format", "{{.State.Pid}}", testContainerName)
 			command.Run(o.BaseOpt, "exec", testContainerName, "sh", "-c", fmt.Sprintf("ps -o pid,comm | grep '%s sleep'", pid))
 		})
 
 		ginkgo.It("should share PID namespace with a container with --pid=container:<container>", func() {
-			command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "sleep", "infinity")
+			command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, localImages[defaultImage], "sleep", "infinity")
 			// We are joining the pid namespace that was "created" by testContainerName,
 			// so the pid=1 process will be the main process of testContainerName, which is `sleep`.
 			command.Run(o.BaseOpt, "exec", testContainerName, "sh", "-c", "ps -o pid,comm | grep '1 sleep'")
@@ -269,30 +300,38 @@ func Run(o *RunOption) {
 				network := network
 				ginkgo.It(fmt.Sprintf("should connect a container to a network with %s flag", network), func() {
 					command.Run(o.BaseOpt, "run", "-d", network, "bridge", "--name", testContainerName,
-						localImages["defaultImage"], "sh", "-c", "echo hello | nc -l -p 80")
+						localImages[defaultImage], "sh", "-c", "echo hello | nc -l -p 80")
 					ipAddr := command.StdoutStr(o.BaseOpt, "inspect", "--format",
 						"{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", testContainerName)
-					output := command.StdoutStr(o.BaseOpt, "run", network, "bridge", localImages["defaultImage"], "nc", fmt.Sprintf("%s:80", ipAddr))
+					output := command.StdoutStr(
+						o.BaseOpt,
+						"run",
+						network,
+						"bridge",
+						localImages[defaultImage],
+						"nc",
+						fmt.Sprintf("%s:80", ipAddr),
+					)
 					gomega.Expect(output).Should(gomega.Equal("hello"))
 				})
 
 				ginkgo.It(fmt.Sprintf("should use the same network with container specified by %s=container:<name>", network), func() {
 					command.Run(o.BaseOpt, "run", "-d", network, "bridge", "--name", testContainerName,
-						localImages["defaultImage"], "sh", "-c", "echo hello | nc -l -p 80")
+						localImages[defaultImage], "sh", "-c", "echo hello | nc -l -p 80")
 					ipAddr := command.StdoutStr(o.BaseOpt, "inspect", "--format",
 						"{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", testContainerName)
 					output := command.StdoutStr(o.BaseOpt, "run", fmt.Sprintf("%s=container:%s", network, testContainerName),
-						localImages["defaultImage"], "nc", fmt.Sprintf("%s:80", ipAddr))
+						localImages[defaultImage], "nc", fmt.Sprintf("%s:80", ipAddr))
 					gomega.Expect(output).Should(gomega.Equal("hello"))
 				})
 
 				ginkgo.It(fmt.Sprintf("should use the same network with container specified by %s=container:<id>", network), func() {
 					id := command.StdoutStr(o.BaseOpt, "run", "-d", network, "bridge", "--name", testContainerName,
-						localImages["defaultImage"], "sh", "-c", "echo hello | nc -l -p 80")
+						localImages[defaultImage], "sh", "-c", "echo hello | nc -l -p 80")
 					ipAddr := command.StdoutStr(o.BaseOpt, "inspect", "--format",
 						"{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", testContainerName)
 					output := command.StdoutStr(o.BaseOpt, "run", fmt.Sprintf("%s=container:%s", network, id),
-						localImages["defaultImage"], "nc", fmt.Sprintf("%s:80", ipAddr))
+						localImages[defaultImage], "nc", fmt.Sprintf("%s:80", ipAddr))
 					gomega.Expect(output).Should(gomega.Equal("hello"))
 				})
 			}
@@ -300,13 +339,13 @@ func Run(o *RunOption) {
 			ginkgo.It("should be able to set custom DNS servers with --dns flag", func() {
 				const nameserver = "10.10.10.10"
 				lines := command.StdoutAsLines(o.BaseOpt, "run", "--dns", nameserver, "--name", testContainerName,
-					localImages["defaultImage"], "cat", "/etc/resolv.conf")
+					localImages[defaultImage], "cat", "/etc/resolv.conf")
 				gomega.Expect(lines).Should(gomega.ContainElement(fmt.Sprintf("nameserver %s", nameserver)))
 			})
 
 			ginkgo.It("should be able to set custom DNS search domains with --dns-search flag", func() {
 				lines := command.StdoutAsLines(o.BaseOpt, "run", "--dns-search", "test", "--name", testContainerName,
-					localImages["defaultImage"], "cat", "/etc/resolv.conf")
+					localImages[defaultImage], "cat", "/etc/resolv.conf")
 				gomega.Expect(lines).Should(gomega.ContainElement("search test"))
 			})
 
@@ -314,7 +353,7 @@ func Run(o *RunOption) {
 				dnsOption := dnsOption
 				ginkgo.It(fmt.Sprintf("should be able to set DNS option with %s flag", dnsOption), func() {
 					lines := command.StdoutAsLines(o.BaseOpt, "run", dnsOption, "debug", "--name", testContainerName,
-						localImages["defaultImage"], "cat", "/etc/resolv.conf")
+						localImages[defaultImage], "cat", "/etc/resolv.conf")
 					gomega.Expect(lines).Should(gomega.ContainElement("options debug"))
 				})
 			}
@@ -322,13 +361,21 @@ func Run(o *RunOption) {
 			for _, hostname := range []string{"--hostname", "-h"} {
 				hostname := hostname
 				ginkgo.It(fmt.Sprintf("should be able to set container host name with %s flag", hostname), func() {
-					name := command.StdoutStr(o.BaseOpt, "run", hostname, "foo", localImages["defaultImage"], "hostname")
+					name := command.StdoutStr(o.BaseOpt, "run", hostname, "foo", localImages[defaultImage], "hostname")
 					gomega.Expect(name).Should(gomega.Equal("foo"))
 				})
 			}
 
 			ginkgo.It("should add a custom host-to-IP mapping with --add-host flag", func() {
-				mapping := command.StdoutStr(o.BaseOpt, "run", "--add-host", "test-host:6.6.6.6", localImages["defaultImage"], "cat", "/etc/hosts")
+				mapping := command.StdoutStr(
+					o.BaseOpt,
+					"run",
+					"--add-host",
+					"test-host:6.6.6.6",
+					localImages[defaultImage],
+					"cat",
+					"/etc/hosts",
+				)
 				gomega.Expect(mapping).Should(gomega.ContainSubstring("6.6.6.6"))
 				gomega.Expect(mapping).Should(gomega.ContainSubstring("test-host"))
 			})
@@ -336,7 +383,7 @@ func Run(o *RunOption) {
 			ginkgo.It("should add a custom host-to-IP mapping with --add-host flag with special IP", func(ctx ginkgo.SpecContext) {
 				response := "This is the expected response for --add-host special IP test."
 				mux := http.NewServeMux()
-				mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 					io.WriteString(w, response) //nolint:errcheck,gosec // Function call in server handler for testing only.
 				})
 				hostPort := fnet.GetFreePort()
@@ -344,14 +391,14 @@ func Run(o *RunOption) {
 				go s.ListenAndServe() //nolint:errcheck // Asynchronously starting server for testing only.
 				ginkgo.DeferCleanup(s.Shutdown, ctx)
 				command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, "--add-host", "test-host:host-gateway",
-					localImages["amazonLinux2Image"], "sleep", "infinity")
+					localImages[amazonLinux2Image], "sleep", "infinity")
 				mapping := command.StdoutStr(o.BaseOpt, "exec", testContainerName, "cat", "/etc/hosts")
 				gomega.Expect(mapping).Should(gomega.ContainSubstring(o.DefaultHostGatewayIP))
 				gomega.Expect(mapping).Should(gomega.ContainSubstring("test-host"))
 				gomega.Expect(command.StdoutStr(o.BaseOpt, "exec", testContainerName, "curl",
 					fmt.Sprintf("test-host:%d", hostPort))).Should(gomega.Equal(response))
 				command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName2, "--add-host=test-host:host-gateway",
-					localImages["amazonLinux2Image"], "sleep", "infinity")
+					localImages[amazonLinux2Image], "sleep", "infinity")
 				mapping = command.StdoutStr(o.BaseOpt, "exec", testContainerName2, "cat", "/etc/hosts")
 				gomega.Expect(mapping).Should(gomega.ContainSubstring(o.DefaultHostGatewayIP))
 				gomega.Expect(mapping).Should(gomega.ContainSubstring("test-host"))
@@ -367,7 +414,7 @@ func Run(o *RunOption) {
 					// Start an Nginx container in detached mode with the specified publish flag and mapping the container port to
 					// a randomly selected host port.
 					command.
-						New(o.BaseOpt, "run", "-d", publish, fmt.Sprintf("%d:%d", hostPort, containerPort), localImages["nginxImage"]).
+						New(o.BaseOpt, "run", "-d", publish, fmt.Sprintf("%d:%d", hostPort, containerPort), localImages[nginxImage]).
 						WithTimeoutInSeconds(20).
 						Run()
 					fnet.HTTPGetAndAssert(fmt.Sprintf("http://localhost:%d", hostPort), 200, 20, 200*time.Millisecond)
@@ -386,19 +433,19 @@ func Run(o *RunOption) {
 				volume := volume
 				ginkgo.It(fmt.Sprintf("should mount a volume when running a container with %s", volume), func() {
 					command.Run(o.BaseOpt, "run", "--name", testContainerName, volume,
-						fmt.Sprintf("%s:%s", testVolumeName, destDir), localImages["defaultImage"], "sh", "-c", "echo foo > /tmp/test.txt")
+						fmt.Sprintf("%s:%s", testVolumeName, destDir), localImages[defaultImage], "sh", "-c", "echo foo > /tmp/test.txt")
 					srcDir := command.StdoutStr(o.BaseOpt, "volume", "inspect", testVolumeName, "--format", "{{.Mountpoint}}")
 					expectedMount := []MountJSON{makeMount(volumeType, srcDir, destDir, "", true)}
 					actualMount := getContainerMounts(o.BaseOpt, testContainerName)
 					verifyMountsInfo(actualMount, expectedMount)
-					output := command.StdoutStr(o.BaseOpt, "run", "-v", fmt.Sprintf("%s:/tmp", testVolumeName), localImages["defaultImage"],
+					output := command.StdoutStr(o.BaseOpt, "run", "-v", fmt.Sprintf("%s:/tmp", testVolumeName), localImages[defaultImage],
 						"cat", "/tmp/test.txt")
 					gomega.Expect(output).Should(gomega.Equal("foo"))
 				})
 
 				ginkgo.It(fmt.Sprintf("should be able to set the volume options with %s testVol:%s:ro", volume, destDir), func() {
 					command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, volume,
-						fmt.Sprintf("%s:%s:ro", testVolumeName, destDir), localImages["defaultImage"], "sleep", "infinity")
+						fmt.Sprintf("%s:%s:ro", testVolumeName, destDir), localImages[defaultImage], "sleep", "infinity")
 					srcDir := command.StdoutStr(o.BaseOpt, "volume", "inspect", "--format", "{{.Mountpoint}}", testVolumeName)
 					expectedMount := []MountJSON{makeMount(volumeType, srcDir, destDir, "ro", false)}
 					actualMount := getContainerMounts(o.BaseOpt, testContainerName)
@@ -412,7 +459,7 @@ func Run(o *RunOption) {
 			ginkgo.It("should create a tmpfs mount in a container", func() {
 				const tmpfsContainerName = "tmpfs-ctr"
 				command.Run(o.BaseOpt, "run", "-d", "--tmpfs", fmt.Sprintf("%s:size=64m,exec", destDir),
-					"--name", tmpfsContainerName, localImages["defaultImage"], "sleep", "infinity")
+					"--name", tmpfsContainerName, localImages[defaultImage], "sleep", "infinity")
 				expectedMount := []MountJSON{makeMount(tmpfsType, tmpfsType, destDir, "size=64m,exec", true)}
 				actualMount := getContainerMounts(o.BaseOpt, tmpfsContainerName)
 				verifyMountsInfo(actualMount, expectedMount)
@@ -430,7 +477,7 @@ func Run(o *RunOption) {
 				ginkgo.DeferCleanup(os.RemoveAll, fileDir)
 				command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, "--mount",
 					fmt.Sprintf("type=bind,source=%s,target=%s", fileDir, destDir),
-					localImages["defaultImage"], "sleep", "infinity")
+					localImages[defaultImage], "sleep", "infinity")
 
 				if runtime.GOOS == "windows" {
 					fileDir, err = getWslPath(fileDir)
@@ -452,7 +499,7 @@ func Run(o *RunOption) {
 				// verify the bind mount is readonly by piping the command of creating a file in the interactive mode to the container
 				command.New(o.BaseOpt, "run", "-i", "--name", testContainerName, "--mount",
 					fmt.Sprintf("type=bind,source=%s,target=%s,ro", fileDir, destDir),
-					localImages["defaultImage"]).WithStdin(gbytes.BufferWithBytes(cmd)).WithoutSuccessfulExit().Run()
+					localImages[defaultImage]).WithStdin(gbytes.BufferWithBytes(cmd)).WithoutSuccessfulExit().Run()
 
 				if runtime.GOOS == "windows" {
 					fileDir, err = getWslPath(fileDir)
@@ -488,14 +535,14 @@ func Run(o *RunOption) {
 				output := command.StdoutStr(o.BaseOpt, "run", "--rm", "--name", testContainerName,
 					"-v", nestedHostDir+":"+nestedContainerDir,
 					"-v", tempDir+":"+containerOuterDir,
-					localImages["defaultImage"], "sh", "-c", "ls "+nestedContainerDir)
+					localImages[defaultImage], "sh", "-c", "ls "+nestedContainerDir)
 				gomega.Expect(output).Should(gomega.ContainSubstring("file1.txt"))
 
 				// Mount parent directory first followed by nested
 				output = command.StdoutStr(o.BaseOpt, "run", "--rm", "--name", testContainerName2,
 					"-v", tempDir+":"+containerOuterDir,
 					"-v", nestedHostDir+":"+nestedContainerDir,
-					localImages["defaultImage"], "sh", "-c", "ls "+nestedContainerDir)
+					localImages[defaultImage], "sh", "-c", "ls "+nestedContainerDir)
 				gomega.Expect(output).Should(gomega.ContainSubstring("file1.txt"))
 			})
 
@@ -503,7 +550,7 @@ func Run(o *RunOption) {
 				tmpfsDir := "/tmpfsDir"
 				command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, "--mount",
 					fmt.Sprintf("type=tmpfs,destination=%s,tmpfs-mode=1770,tmpfs-size=64m", tmpfsDir),
-					localImages["defaultImage"], "sleep", "infinity")
+					localImages[defaultImage], "sleep", "infinity")
 				expectedMount := []MountJSON{makeMount(tmpfsType, tmpfsType, tmpfsDir, "mode=1770,size=64m", true)}
 				actualMount := getContainerMounts(o.BaseOpt, testContainerName)
 				verifyMountsInfo(actualMount, expectedMount)
@@ -516,7 +563,7 @@ func Run(o *RunOption) {
 
 			ginkgo.It("should mount a volume using --mount type=volume flag", func() {
 				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--mount",
-					fmt.Sprintf("type=volume,source=%s,target=%s", testVolumeName, destDir), localImages["defaultImage"])
+					fmt.Sprintf("type=volume,source=%s,target=%s", testVolumeName, destDir), localImages[defaultImage])
 				srcDir := command.StdoutStr(o.BaseOpt, "volume", "inspect", testVolumeName, "--format", "{{.Mountpoint}}")
 				expectedMount := []MountJSON{makeMount(volumeType, srcDir, destDir, "", true)}
 				actualMount := getContainerMounts(o.BaseOpt, testContainerName)
@@ -532,13 +579,23 @@ func Run(o *RunOption) {
 				}
 			})
 			ginkgo.It("should set number of CPUs with --cpus flag", func() {
-				cpuMax := command.StdoutStr(o.BaseOpt, "run", "--cpus", "0.42", "-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "cpu.max")
+				cpuMax := command.StdoutStr(
+					o.BaseOpt,
+					"run",
+					"--cpus",
+					"0.42",
+					"-w",
+					"/sys/fs/cgroup",
+					localImages[defaultImage],
+					"cat",
+					"cpu.max",
+				)
 				gomega.Expect(cpuMax).To(gomega.Equal("42000 100000"))
 			})
 
 			ginkgo.It("should limit CPU CFS (Completely Fair Scheduler) quota and period with --cpu-quota and --cpu-period flags", func() {
 				cpuMax := command.StdoutStr(o.BaseOpt, "run", "--cpu-quota", "42000",
-					"--cpu-period", "100000", "-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "cpu.max")
+					"--cpu-period", "100000", "-w", "/sys/fs/cgroup", localImages[defaultImage], "cat", "cpu.max")
 				gomega.Expect(cpuMax).To(gomega.Equal("42000 100000"))
 			})
 
@@ -547,7 +604,7 @@ func Run(o *RunOption) {
 				//nolint: lll // the source of the CPUShares calculation formula
 				// Ref. https://github.com/google/cadvisor/blob/ce07bb28eadc18183df15ca5346293af6b020b33/integration/tests/api/docker_test.go#L216-L222
 				cpuWeight := command.StdoutStr(o.BaseOpt, "run", "--rm", "--cpu-shares", "2000",
-					"-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "cpu.weight")
+					"-w", "/sys/fs/cgroup", localImages[defaultImage], "cat", "cpu.weight")
 				gomega.Expect(cpuWeight).To(gomega.Equal("77"))
 			})
 
@@ -555,19 +612,19 @@ func Run(o *RunOption) {
 			ginkgo.When("--cpuset-cpus is used", func() {
 				ginkgo.It("should set CPUs in which to allow execution as cpu 1 with --cpuset-cpus=1", func() {
 					cpuSet := command.StdoutStr(o.BaseOpt, "run", "--cpuset-cpus", "1",
-						"-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "cpuset.cpus")
+						"-w", "/sys/fs/cgroup", localImages[defaultImage], "cat", "cpuset.cpus")
 					gomega.Expect(cpuSet).To(gomega.Equal("1"))
 				})
 
 				ginkgo.It("should set CPUs in which to allow execution as cpu 0-1 with --cpuset-cpus=0-1", func() {
 					cpuSet := command.StdoutStr(o.BaseOpt, "run", "--cpuset-cpus", "0-1",
-						"-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "cpuset.cpus")
+						"-w", "/sys/fs/cgroup", localImages[defaultImage], "cat", "cpuset.cpus")
 					gomega.Expect(cpuSet).To(gomega.Equal("0-1"))
 				})
 
 				ginkgo.It("should set CPUs in which to allow execution as cpu 0-1 with --cpuset-cpus=0,1", func() {
 					cpuSet := command.StdoutStr(o.BaseOpt, "run", "--cpuset-cpus", "0,1",
-						"-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "cpuset.cpus")
+						"-w", "/sys/fs/cgroup", localImages[defaultImage], "cat", "cpuset.cpus")
 					gomega.Expect(cpuSet).To(gomega.Equal("0-1"))
 				})
 			})
@@ -577,31 +634,31 @@ func Run(o *RunOption) {
 			// https://man7.org/linux/man-pages/man7/cpuset.7.html#WARNINGS
 			ginkgo.It("should set memory nodes (MEMs) in which to allow execution as memory node 0 with --cpuset-mems=0", func() {
 				cpuMems := command.StdoutStr(o.BaseOpt, "run", "--cpuset-mems", "0",
-					"-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "cpuset.mems")
+					"-w", "/sys/fs/cgroup", localImages[defaultImage], "cat", "cpuset.mems")
 				gomega.Expect(cpuMems).To(gomega.Equal("0"))
 			})
 
 			ginkgo.It("should set the memory limit with --memory", func() {
 				mem := command.StdoutStr(o.BaseOpt, "run", "--memory", "42m",
-					"-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "memory.max")
+					"-w", "/sys/fs/cgroup", localImages[defaultImage], "cat", "memory.max")
 				gomega.Expect(mem).To(gomega.Equal("44040192"))
 			})
 
 			ginkgo.It("should set the memory soft limit with --memory-reservation", func() {
 				mem := command.StdoutStr(o.BaseOpt, "run", "--memory-reservation", "6m",
-					"-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "memory.low")
+					"-w", "/sys/fs/cgroup", localImages[defaultImage], "cat", "memory.low")
 				gomega.Expect(mem).To(gomega.Equal("6291456"))
 			})
 
 			ginkgo.It("should set the amount of memory this container is allowed to swap to disk with --memory-swap", func() {
 				mem := command.StdoutStr(o.BaseOpt, "run", "--memory", "42m", "--memory-swap", "100m",
-					"-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "memory.max", "memory.swap.max")
+					"-w", "/sys/fs/cgroup", localImages[defaultImage], "cat", "memory.max", "memory.swap.max")
 				gomega.Expect(mem).To(gomega.Equal("44040192\n60817408"))
 			})
 
 			ginkgo.It("should set the container pids limit with --pids-limit", func() {
 				pidsLimit := command.StdoutStr(o.BaseOpt, "run", "--pids-limit", "42",
-					"-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "pids.max")
+					"-w", "/sys/fs/cgroup", localImages[defaultImage], "cat", "pids.max")
 				gomega.Expect(pidsLimit).To(gomega.Equal("42"))
 			})
 
@@ -609,7 +666,15 @@ func Run(o *RunOption) {
 				// 100 is the minimum because finch VM runs rootless containerd inside.
 				testcases := []string{"100", "1000"}
 				for _, tc := range testcases {
-					score := command.StdoutStr(o.BaseOpt, "run", "--oom-score-adj", tc, localImages["defaultImage"], "cat", "/proc/self/oom_score_adj")
+					score := command.StdoutStr(
+						o.BaseOpt,
+						"run",
+						"--oom-score-adj",
+						tc,
+						localImages[defaultImage],
+						"cat",
+						"/proc/self/oom_score_adj",
+					)
 					gomega.Expect(score).To(gomega.Equal(tc))
 				}
 			})
@@ -635,7 +700,7 @@ func Run(o *RunOption) {
 					"nobody:100":   {"uid=65534(nobody) gid=100(users)", "uid=65534(nobody) gid=100(users) groups=100(users)"},
 				}
 				for userStr, expected := range testCases {
-					output := command.StdoutStr(o.BaseOpt, "run", user, userStr, localImages["defaultImage"], "id")
+					output := command.StdoutStr(o.BaseOpt, "run", user, userStr, localImages[defaultImage], "id")
 					// TODO: Remove the Or operator after upgrading the nerdctl dependency to 1.2.1 to only match expected[1]
 					gomega.Expect(output).Should(gomega.Or(gomega.Equal(expected[0]), gomega.Equal(expected[1])))
 				}
@@ -674,7 +739,7 @@ func Run(o *RunOption) {
 					for _, group := range tc.groups {
 						args = append(args, "--group-add", group)
 					}
-					args = append(args, localImages["defaultImage"], "id")
+					args = append(args, localImages[defaultImage], "id")
 					output := command.StdoutStr(o.BaseOpt, args...)
 					// TODO: Remove the Or operator after upgrading the nerdctl dependency to 1.2.1 to only match tc.expected[1]
 					gomega.Expect(output).Should(gomega.Or(gomega.Equal(tc.expected[0]), gomega.Equal(tc.expected[1])))

--- a/tests/run.go
+++ b/tests/run.go
@@ -50,7 +50,7 @@ func Run(o *RunOption) {
 			ginkgo.BeforeEach(func() {
 				dockerfile := fmt.Sprintf(`FROM %s
 			CMD ["echo", "finch-test-dummy-output"]
-			`, defaultImage)
+			`, localImages["defaultImage"])
 				buildContext := ffs.CreateBuildContext(dockerfile)
 				ginkgo.DeferCleanup(os.RemoveAll, buildContext)
 				command.Run(o.BaseOpt, "build", "-q", "-t", testImageName, buildContext)
@@ -68,7 +68,7 @@ func Run(o *RunOption) {
 		})
 
 		ginkgo.It("with --rm flag, container should be removed when it exits", func() {
-			command.Run(o.BaseOpt, "run", "--rm", "--name", testContainerName, defaultImage)
+			command.Run(o.BaseOpt, "run", "--rm", "--name", testContainerName, localImages["defaultImage"])
 			err := containerShouldNotExist(o.BaseOpt, testContainerName)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
@@ -77,7 +77,7 @@ func Run(o *RunOption) {
 			for _, label := range []string{"-l", "--label"} {
 				label := label
 				ginkgo.It(fmt.Sprintf("should set meta data on a container with %s flag", label), func() {
-					command.Run(o.BaseOpt, "run", "--name", testContainerName, label, "testKey=testValue", defaultImage)
+					command.Run(o.BaseOpt, "run", "--name", testContainerName, label, "testKey=testValue", localImages["defaultImage"])
 					gomega.Expect(command.StdoutStr(o.BaseOpt, "inspect", testContainerName,
 						"--format", "{{.Config.Labels.testKey}}")).To(gomega.Equal("testValue"))
 				})
@@ -87,7 +87,7 @@ func Run(o *RunOption) {
 				dir := ffs.CreateTempDir("finch-test-cid")
 				ginkgo.DeferCleanup(os.RemoveAll, dir)
 				path := filepath.Join(dir, "test.cid")
-				containerID := command.StdoutStr(o.BaseOpt, "run", "-d", "--cidfile", path, defaultImage)
+				containerID := command.StdoutStr(o.BaseOpt, "run", "-d", "--cidfile", path, localImages["defaultImage"])
 				output, err := os.ReadFile(filepath.Clean(path))
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				gomega.Expect(strings.TrimSpace(string(output))).Should(gomega.Equal(containerID))
@@ -96,7 +96,7 @@ func Run(o *RunOption) {
 			ginkgo.It("should read labels from file with --label-file flag", func() {
 				path := ffs.CreateTempFile("label-file", "key=value")
 				ginkgo.DeferCleanup(os.RemoveAll, filepath.Dir(path))
-				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--label-file", path, defaultImage)
+				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--label-file", path, localImages["defaultImage"])
 				gomega.Expect(command.StdoutStr(o.BaseOpt, "inspect", testContainerName,
 					"--format", "{{.Config.Labels.key}}")).To(gomega.Equal("value"))
 			})
@@ -107,7 +107,7 @@ func Run(o *RunOption) {
 				dockerfile := fmt.Sprintf(`FROM %s
 		ENTRYPOINT ["echo", "foo"]
 		CMD ["echo", "bar"]
-			`, defaultImage)
+			`, localImages["defaultImage"])
 				buildContext := ffs.CreateBuildContext(dockerfile)
 				defer func() {
 					gomega.Expect(os.RemoveAll(buildContext)).To(gomega.Succeed())
@@ -124,7 +124,7 @@ func Run(o *RunOption) {
 				workDir := workDir
 				ginkgo.It(fmt.Sprintf("should set working directory inside the container specified by %s flag", workDir), func() {
 					dir := "/tmp"
-					gomega.Expect(command.StdoutStr(o.BaseOpt, "run", workDir, dir, defaultImage, "pwd")).Should(gomega.Equal(dir))
+					gomega.Expect(command.StdoutStr(o.BaseOpt, "run", workDir, dir, localImages["defaultImage"], "pwd")).Should(gomega.Equal(dir))
 				})
 			}
 
@@ -133,7 +133,7 @@ func Run(o *RunOption) {
 				ginkgo.It(fmt.Sprintf("with %s flag, environment variables should be set in the container", env), func() {
 					envOutput := command.Stdout(o.BaseOpt, "run", "--rm",
 						env, "FOO=BAR", env, "FOO1", env, "ENV1=1", env, "ENV1=2",
-						defaultImage, "env")
+						localImages["defaultImage"], "env")
 					gomega.Expect(envOutput).To(gomega.ContainSubstring("FOO=BAR"))
 					gomega.Expect(envOutput).ToNot(gomega.ContainSubstring("FOO1"))
 					gomega.Expect(envOutput).To(gomega.ContainSubstring("ENV1=2"))
@@ -143,7 +143,7 @@ func Run(o *RunOption) {
 			ginkgo.It("with -e flag passing env variables without a value, only host set vars should be set in the container", func() {
 				gomega.Expect(os.Setenv("AVAR1", "avalue")).To(gomega.Succeed())
 				envOutput := command.Stdout(o.BaseOpt, "run", "--rm",
-					"-e", "AVAR1", "-e", "AVAR2", defaultImage, "env")
+					"-e", "AVAR1", "-e", "AVAR2", localImages["defaultImage"], "env")
 				gomega.Expect(envOutput).To(gomega.ContainSubstring("AVAR1=avalue"))
 				gomega.Expect(envOutput).ToNot(gomega.ContainSubstring("AVAR2"))
 			})
@@ -153,7 +153,7 @@ func Run(o *RunOption) {
 				envPath := ffs.CreateTempFile("env", envPair)
 				ginkgo.DeferCleanup(os.RemoveAll, filepath.Dir(envPath))
 
-				envOutput := command.Stdout(o.BaseOpt, "run", "--rm", "--env-file", envPath, defaultImage, "env")
+				envOutput := command.Stdout(o.BaseOpt, "run", "--rm", "--env-file", envPath, localImages["defaultImage"], "env")
 				gomega.Expect(envOutput).To(gomega.ContainSubstring(envPair))
 			})
 
@@ -162,7 +162,7 @@ func Run(o *RunOption) {
 				envPath := ffs.CreateTempFile("env", envPair)
 				ginkgo.DeferCleanup(os.RemoveAll, filepath.Dir(envPath))
 				gomega.Expect(os.Setenv("AVAR1", "avalue")).To(gomega.Succeed())
-				envOutput := command.Stdout(o.BaseOpt, "run", "--rm", "--env-file", envPath, defaultImage, "env")
+				envOutput := command.Stdout(o.BaseOpt, "run", "--rm", "--env-file", envPath, localImages["defaultImage"], "env")
 				gomega.Expect(envOutput).To(gomega.ContainSubstring("ENVKEY=ENVVAL"))
 				gomega.Expect(envOutput).To(gomega.ContainSubstring("AVAR1=avalue"))
 				gomega.Expect(envOutput).ToNot(gomega.ContainSubstring("AVAR2"))
@@ -173,7 +173,7 @@ func Run(o *RunOption) {
 				envPath := ffs.CreateTempFile("env", envPair)
 				ginkgo.DeferCleanup(os.RemoveAll, filepath.Dir(envPath))
 				gomega.Expect(os.Setenv("AVAR1", "avalue")).To(gomega.Succeed())
-				envOutput := command.Stdout(o.BaseOpt, "run", "--rm", "--env-file", envPath, defaultImage, "env")
+				envOutput := command.Stdout(o.BaseOpt, "run", "--rm", "--env-file", envPath, localImages["defaultImage"], "env")
 				gomega.Expect(envOutput).To(gomega.ContainSubstring("ENVKEY=ENVVAL"))
 				gomega.Expect(envOutput).To(gomega.ContainSubstring("AVAR1=avalue"))
 				gomega.Expect(envOutput).ToNot(gomega.ContainSubstring("AVAR2"))
@@ -182,37 +182,37 @@ func Run(o *RunOption) {
 
 		ginkgo.When("running an image with --pull flag", func() {
 			ginkgo.It("should have an error if set --pull=never and the image doesn't exist", func() {
-				command.RunWithoutSuccessfulExit(o.BaseOpt, "run", "--pull", "never", defaultImage)
-				imageShouldNotExist(o.BaseOpt, defaultImage)
+				command.RunWithoutSuccessfulExit(o.BaseOpt, "run", "--pull", "never", localImages["defaultImage"])
+				imageShouldNotExist(o.BaseOpt, localImages["defaultImage"])
 			})
 
 			ginkgo.It("should be able to run the container if set --pull=never and the image exists", func() {
 				const containerName = "test-container"
-				pullImage(o.BaseOpt, defaultImage)
-				command.Run(o.BaseOpt, "run", "--name", containerName, "--pull", "never", defaultImage)
+				pullImage(o.BaseOpt, localImages["defaultImage"])
+				command.Run(o.BaseOpt, "run", "--name", containerName, "--pull", "never", localImages["defaultImage"])
 				containerShouldExist(o.BaseOpt, containerName)
 			})
 
 			ginkgo.It("should be able to run the container if set --pull=missing and the image doesn't exist", func() {
-				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--pull", "missing", defaultImage)
+				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--pull", "missing", localImages["defaultImage"])
 				containerShouldExist(o.BaseOpt, testContainerName)
-				imageShouldExist(o.BaseOpt, defaultImage)
+				imageShouldExist(o.BaseOpt, localImages["defaultImage"])
 			})
 
 			ginkgo.It("should be able to run the container if set --pull=missing and the image exists", func() {
-				pullImage(o.BaseOpt, defaultImage)
-				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--pull", "missing", defaultImage)
+				pullImage(o.BaseOpt, localImages["defaultImage"])
+				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--pull", "missing", localImages["defaultImage"])
 				containerShouldExist(o.BaseOpt, testContainerName)
 			})
 
 			ginkgo.It("should be able to run the container if set --pull=always and the image doesn't exist", func() {
-				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--pull", "always", defaultImage)
+				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--pull", "always", localImages["defaultImage"])
 				containerShouldExist(o.BaseOpt, testContainerName)
-				imageShouldExist(o.BaseOpt, defaultImage)
+				imageShouldExist(o.BaseOpt, localImages["defaultImage"])
 			})
 			ginkgo.It("should be able to run the container if set --pull=always and the image exists", func() {
-				pullImage(o.BaseOpt, defaultImage)
-				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--pull", "always", defaultImage)
+				pullImage(o.BaseOpt, localImages["defaultImage"])
+				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--pull", "always", localImages["defaultImage"])
 			})
 		})
 
@@ -220,7 +220,7 @@ func Run(o *RunOption) {
 			interactive := interactive
 			ginkgo.It(fmt.Sprintf("should output string if %s flag keeps STDIN open", interactive), func() {
 				want := []byte("hello")
-				got := command.New(o.BaseOpt, "run", interactive, defaultImage, "cat").
+				got := command.New(o.BaseOpt, "run", interactive, localImages["defaultImage"], "cat").
 					WithStdin(gbytes.BufferWithBytes(want)).Run().Out.Contents()
 				gomega.Expect(got).Should(gomega.Equal(want))
 			})
@@ -229,7 +229,7 @@ func Run(o *RunOption) {
 		ginkgo.It("should stop running container within specified time by --stop-timeout flag", func() {
 			// With PID=1, `sleep infinity` does not exit due to receiving a SIGTERM, which is sent by the stop command.
 			// Ref. https://superuser.com/a/1299463/730265
-			command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, "--stop-timeout", "1", defaultImage, "sleep", "infinity")
+			command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, "--stop-timeout", "1", localImages["defaultImage"], "sleep", "infinity")
 			gomega.Expect(command.StdoutStr(o.BaseOpt, "exec", testContainerName, "echo", "foo")).To(gomega.Equal("foo"))
 			startTime := time.Now()
 			command.Run(o.BaseOpt, "stop", testContainerName)
@@ -240,7 +240,7 @@ func Run(o *RunOption) {
 
 		ginkgo.It("should immediately stop the container with --stop-signal=SIGKILL", func() {
 			// With PID=1, `sleep infinity` will only exit when receiving SIGKILL, while the signal sent by stop command is SIGTERM.
-			command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, "--stop-signal", "SIGKILL", defaultImage, "sleep", "infinity")
+			command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, "--stop-signal", "SIGKILL", localImages["defaultImage"], "sleep", "infinity")
 			containerShouldBeRunning(o.BaseOpt, testContainerName)
 			startTime := time.Now()
 			command.Run(o.BaseOpt, "stop", testContainerName)
@@ -251,13 +251,13 @@ func Run(o *RunOption) {
 		})
 
 		ginkgo.It("should share PID namespace with host with --pid=host", func() {
-			command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, "--pid=host", defaultImage, "sleep", "infinity")
+			command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, "--pid=host", localImages["defaultImage"], "sleep", "infinity")
 			pid := command.StdoutStr(o.BaseOpt, "inspect", "--format", "{{.State.Pid}}", testContainerName)
 			command.Run(o.BaseOpt, "exec", testContainerName, "sh", "-c", fmt.Sprintf("ps -o pid,comm | grep '%s sleep'", pid))
 		})
 
 		ginkgo.It("should share PID namespace with a container with --pid=container:<container>", func() {
-			command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, defaultImage, "sleep", "infinity")
+			command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "sleep", "infinity")
 			// We are joining the pid namespace that was "created" by testContainerName,
 			// so the pid=1 process will be the main process of testContainerName, which is `sleep`.
 			command.Run(o.BaseOpt, "exec", testContainerName, "sh", "-c", "ps -o pid,comm | grep '1 sleep'")
@@ -269,30 +269,30 @@ func Run(o *RunOption) {
 				network := network
 				ginkgo.It(fmt.Sprintf("should connect a container to a network with %s flag", network), func() {
 					command.Run(o.BaseOpt, "run", "-d", network, "bridge", "--name", testContainerName,
-						defaultImage, "sh", "-c", "echo hello | nc -l -p 80")
+						localImages["defaultImage"], "sh", "-c", "echo hello | nc -l -p 80")
 					ipAddr := command.StdoutStr(o.BaseOpt, "inspect", "--format",
 						"{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", testContainerName)
-					output := command.StdoutStr(o.BaseOpt, "run", network, "bridge", defaultImage, "nc", fmt.Sprintf("%s:80", ipAddr))
+					output := command.StdoutStr(o.BaseOpt, "run", network, "bridge", localImages["defaultImage"], "nc", fmt.Sprintf("%s:80", ipAddr))
 					gomega.Expect(output).Should(gomega.Equal("hello"))
 				})
 
 				ginkgo.It(fmt.Sprintf("should use the same network with container specified by %s=container:<name>", network), func() {
 					command.Run(o.BaseOpt, "run", "-d", network, "bridge", "--name", testContainerName,
-						defaultImage, "sh", "-c", "echo hello | nc -l -p 80")
+						localImages["defaultImage"], "sh", "-c", "echo hello | nc -l -p 80")
 					ipAddr := command.StdoutStr(o.BaseOpt, "inspect", "--format",
 						"{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", testContainerName)
 					output := command.StdoutStr(o.BaseOpt, "run", fmt.Sprintf("%s=container:%s", network, testContainerName),
-						defaultImage, "nc", fmt.Sprintf("%s:80", ipAddr))
+						localImages["defaultImage"], "nc", fmt.Sprintf("%s:80", ipAddr))
 					gomega.Expect(output).Should(gomega.Equal("hello"))
 				})
 
 				ginkgo.It(fmt.Sprintf("should use the same network with container specified by %s=container:<id>", network), func() {
 					id := command.StdoutStr(o.BaseOpt, "run", "-d", network, "bridge", "--name", testContainerName,
-						defaultImage, "sh", "-c", "echo hello | nc -l -p 80")
+						localImages["defaultImage"], "sh", "-c", "echo hello | nc -l -p 80")
 					ipAddr := command.StdoutStr(o.BaseOpt, "inspect", "--format",
 						"{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", testContainerName)
 					output := command.StdoutStr(o.BaseOpt, "run", fmt.Sprintf("%s=container:%s", network, id),
-						defaultImage, "nc", fmt.Sprintf("%s:80", ipAddr))
+						localImages["defaultImage"], "nc", fmt.Sprintf("%s:80", ipAddr))
 					gomega.Expect(output).Should(gomega.Equal("hello"))
 				})
 			}
@@ -300,13 +300,13 @@ func Run(o *RunOption) {
 			ginkgo.It("should be able to set custom DNS servers with --dns flag", func() {
 				const nameserver = "10.10.10.10"
 				lines := command.StdoutAsLines(o.BaseOpt, "run", "--dns", nameserver, "--name", testContainerName,
-					defaultImage, "cat", "/etc/resolv.conf")
+					localImages["defaultImage"], "cat", "/etc/resolv.conf")
 				gomega.Expect(lines).Should(gomega.ContainElement(fmt.Sprintf("nameserver %s", nameserver)))
 			})
 
 			ginkgo.It("should be able to set custom DNS search domains with --dns-search flag", func() {
 				lines := command.StdoutAsLines(o.BaseOpt, "run", "--dns-search", "test", "--name", testContainerName,
-					defaultImage, "cat", "/etc/resolv.conf")
+					localImages["defaultImage"], "cat", "/etc/resolv.conf")
 				gomega.Expect(lines).Should(gomega.ContainElement("search test"))
 			})
 
@@ -314,7 +314,7 @@ func Run(o *RunOption) {
 				dnsOption := dnsOption
 				ginkgo.It(fmt.Sprintf("should be able to set DNS option with %s flag", dnsOption), func() {
 					lines := command.StdoutAsLines(o.BaseOpt, "run", dnsOption, "debug", "--name", testContainerName,
-						defaultImage, "cat", "/etc/resolv.conf")
+						localImages["defaultImage"], "cat", "/etc/resolv.conf")
 					gomega.Expect(lines).Should(gomega.ContainElement("options debug"))
 				})
 			}
@@ -322,13 +322,13 @@ func Run(o *RunOption) {
 			for _, hostname := range []string{"--hostname", "-h"} {
 				hostname := hostname
 				ginkgo.It(fmt.Sprintf("should be able to set container host name with %s flag", hostname), func() {
-					name := command.StdoutStr(o.BaseOpt, "run", hostname, "foo", defaultImage, "hostname")
+					name := command.StdoutStr(o.BaseOpt, "run", hostname, "foo", localImages["defaultImage"], "hostname")
 					gomega.Expect(name).Should(gomega.Equal("foo"))
 				})
 			}
 
 			ginkgo.It("should add a custom host-to-IP mapping with --add-host flag", func() {
-				mapping := command.StdoutStr(o.BaseOpt, "run", "--add-host", "test-host:6.6.6.6", defaultImage, "cat", "/etc/hosts")
+				mapping := command.StdoutStr(o.BaseOpt, "run", "--add-host", "test-host:6.6.6.6", localImages["defaultImage"], "cat", "/etc/hosts")
 				gomega.Expect(mapping).Should(gomega.ContainSubstring("6.6.6.6"))
 				gomega.Expect(mapping).Should(gomega.ContainSubstring("test-host"))
 			})
@@ -344,14 +344,14 @@ func Run(o *RunOption) {
 				go s.ListenAndServe() //nolint:errcheck // Asynchronously starting server for testing only.
 				ginkgo.DeferCleanup(s.Shutdown, ctx)
 				command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, "--add-host", "test-host:host-gateway",
-					amazonLinux2Image, "sleep", "infinity")
+					localImages["amazonLinux2Image"], "sleep", "infinity")
 				mapping := command.StdoutStr(o.BaseOpt, "exec", testContainerName, "cat", "/etc/hosts")
 				gomega.Expect(mapping).Should(gomega.ContainSubstring(o.DefaultHostGatewayIP))
 				gomega.Expect(mapping).Should(gomega.ContainSubstring("test-host"))
 				gomega.Expect(command.StdoutStr(o.BaseOpt, "exec", testContainerName, "curl",
 					fmt.Sprintf("test-host:%d", hostPort))).Should(gomega.Equal(response))
 				command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName2, "--add-host=test-host:host-gateway",
-					amazonLinux2Image, "sleep", "infinity")
+					localImages["amazonLinux2Image"], "sleep", "infinity")
 				mapping = command.StdoutStr(o.BaseOpt, "exec", testContainerName2, "cat", "/etc/hosts")
 				gomega.Expect(mapping).Should(gomega.ContainSubstring(o.DefaultHostGatewayIP))
 				gomega.Expect(mapping).Should(gomega.ContainSubstring("test-host"))
@@ -367,7 +367,7 @@ func Run(o *RunOption) {
 					// Start an Nginx container in detached mode with the specified publish flag and mapping the container port to
 					// a randomly selected host port.
 					command.
-						New(o.BaseOpt, "run", "-d", publish, fmt.Sprintf("%d:%d", hostPort, containerPort), nginxImage).
+						New(o.BaseOpt, "run", "-d", publish, fmt.Sprintf("%d:%d", hostPort, containerPort), localImages["nginxImage"]).
 						WithTimeoutInSeconds(20).
 						Run()
 					fnet.HTTPGetAndAssert(fmt.Sprintf("http://localhost:%d", hostPort), 200, 20, 200*time.Millisecond)
@@ -386,19 +386,19 @@ func Run(o *RunOption) {
 				volume := volume
 				ginkgo.It(fmt.Sprintf("should mount a volume when running a container with %s", volume), func() {
 					command.Run(o.BaseOpt, "run", "--name", testContainerName, volume,
-						fmt.Sprintf("%s:%s", testVolumeName, destDir), defaultImage, "sh", "-c", "echo foo > /tmp/test.txt")
+						fmt.Sprintf("%s:%s", testVolumeName, destDir), localImages["defaultImage"], "sh", "-c", "echo foo > /tmp/test.txt")
 					srcDir := command.StdoutStr(o.BaseOpt, "volume", "inspect", testVolumeName, "--format", "{{.Mountpoint}}")
 					expectedMount := []MountJSON{makeMount(volumeType, srcDir, destDir, "", true)}
 					actualMount := getContainerMounts(o.BaseOpt, testContainerName)
 					verifyMountsInfo(actualMount, expectedMount)
-					output := command.StdoutStr(o.BaseOpt, "run", "-v", fmt.Sprintf("%s:/tmp", testVolumeName), defaultImage,
+					output := command.StdoutStr(o.BaseOpt, "run", "-v", fmt.Sprintf("%s:/tmp", testVolumeName), localImages["defaultImage"],
 						"cat", "/tmp/test.txt")
 					gomega.Expect(output).Should(gomega.Equal("foo"))
 				})
 
 				ginkgo.It(fmt.Sprintf("should be able to set the volume options with %s testVol:%s:ro", volume, destDir), func() {
 					command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, volume,
-						fmt.Sprintf("%s:%s:ro", testVolumeName, destDir), defaultImage, "sleep", "infinity")
+						fmt.Sprintf("%s:%s:ro", testVolumeName, destDir), localImages["defaultImage"], "sleep", "infinity")
 					srcDir := command.StdoutStr(o.BaseOpt, "volume", "inspect", "--format", "{{.Mountpoint}}", testVolumeName)
 					expectedMount := []MountJSON{makeMount(volumeType, srcDir, destDir, "ro", false)}
 					actualMount := getContainerMounts(o.BaseOpt, testContainerName)
@@ -412,7 +412,7 @@ func Run(o *RunOption) {
 			ginkgo.It("should create a tmpfs mount in a container", func() {
 				const tmpfsContainerName = "tmpfs-ctr"
 				command.Run(o.BaseOpt, "run", "-d", "--tmpfs", fmt.Sprintf("%s:size=64m,exec", destDir),
-					"--name", tmpfsContainerName, defaultImage, "sleep", "infinity")
+					"--name", tmpfsContainerName, localImages["defaultImage"], "sleep", "infinity")
 				expectedMount := []MountJSON{makeMount(tmpfsType, tmpfsType, destDir, "size=64m,exec", true)}
 				actualMount := getContainerMounts(o.BaseOpt, tmpfsContainerName)
 				verifyMountsInfo(actualMount, expectedMount)
@@ -430,7 +430,7 @@ func Run(o *RunOption) {
 				ginkgo.DeferCleanup(os.RemoveAll, fileDir)
 				command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, "--mount",
 					fmt.Sprintf("type=bind,source=%s,target=%s", fileDir, destDir),
-					defaultImage, "sleep", "infinity")
+					localImages["defaultImage"], "sleep", "infinity")
 
 				if runtime.GOOS == "windows" {
 					fileDir, err = getWslPath(fileDir)
@@ -452,7 +452,7 @@ func Run(o *RunOption) {
 				// verify the bind mount is readonly by piping the command of creating a file in the interactive mode to the container
 				command.New(o.BaseOpt, "run", "-i", "--name", testContainerName, "--mount",
 					fmt.Sprintf("type=bind,source=%s,target=%s,ro", fileDir, destDir),
-					defaultImage).WithStdin(gbytes.BufferWithBytes(cmd)).WithoutSuccessfulExit().Run()
+					localImages["defaultImage"]).WithStdin(gbytes.BufferWithBytes(cmd)).WithoutSuccessfulExit().Run()
 
 				if runtime.GOOS == "windows" {
 					fileDir, err = getWslPath(fileDir)
@@ -488,14 +488,14 @@ func Run(o *RunOption) {
 				output := command.StdoutStr(o.BaseOpt, "run", "--rm", "--name", testContainerName,
 					"-v", nestedHostDir+":"+nestedContainerDir,
 					"-v", tempDir+":"+containerOuterDir,
-					defaultImage, "sh", "-c", "ls "+nestedContainerDir)
+					localImages["defaultImage"], "sh", "-c", "ls "+nestedContainerDir)
 				gomega.Expect(output).Should(gomega.ContainSubstring("file1.txt"))
 
 				// Mount parent directory first followed by nested
 				output = command.StdoutStr(o.BaseOpt, "run", "--rm", "--name", testContainerName2,
 					"-v", tempDir+":"+containerOuterDir,
 					"-v", nestedHostDir+":"+nestedContainerDir,
-					defaultImage, "sh", "-c", "ls "+nestedContainerDir)
+					localImages["defaultImage"], "sh", "-c", "ls "+nestedContainerDir)
 				gomega.Expect(output).Should(gomega.ContainSubstring("file1.txt"))
 			})
 
@@ -503,7 +503,7 @@ func Run(o *RunOption) {
 				tmpfsDir := "/tmpfsDir"
 				command.Run(o.BaseOpt, "run", "-d", "--name", testContainerName, "--mount",
 					fmt.Sprintf("type=tmpfs,destination=%s,tmpfs-mode=1770,tmpfs-size=64m", tmpfsDir),
-					defaultImage, "sleep", "infinity")
+					localImages["defaultImage"], "sleep", "infinity")
 				expectedMount := []MountJSON{makeMount(tmpfsType, tmpfsType, tmpfsDir, "mode=1770,size=64m", true)}
 				actualMount := getContainerMounts(o.BaseOpt, testContainerName)
 				verifyMountsInfo(actualMount, expectedMount)
@@ -516,7 +516,7 @@ func Run(o *RunOption) {
 
 			ginkgo.It("should mount a volume using --mount type=volume flag", func() {
 				command.Run(o.BaseOpt, "run", "--name", testContainerName, "--mount",
-					fmt.Sprintf("type=volume,source=%s,target=%s", testVolumeName, destDir), defaultImage)
+					fmt.Sprintf("type=volume,source=%s,target=%s", testVolumeName, destDir), localImages["defaultImage"])
 				srcDir := command.StdoutStr(o.BaseOpt, "volume", "inspect", testVolumeName, "--format", "{{.Mountpoint}}")
 				expectedMount := []MountJSON{makeMount(volumeType, srcDir, destDir, "", true)}
 				actualMount := getContainerMounts(o.BaseOpt, testContainerName)
@@ -532,13 +532,13 @@ func Run(o *RunOption) {
 				}
 			})
 			ginkgo.It("should set number of CPUs with --cpus flag", func() {
-				cpuMax := command.StdoutStr(o.BaseOpt, "run", "--cpus", "0.42", "-w", "/sys/fs/cgroup", defaultImage, "cat", "cpu.max")
+				cpuMax := command.StdoutStr(o.BaseOpt, "run", "--cpus", "0.42", "-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "cpu.max")
 				gomega.Expect(cpuMax).To(gomega.Equal("42000 100000"))
 			})
 
 			ginkgo.It("should limit CPU CFS (Completely Fair Scheduler) quota and period with --cpu-quota and --cpu-period flags", func() {
 				cpuMax := command.StdoutStr(o.BaseOpt, "run", "--cpu-quota", "42000",
-					"--cpu-period", "100000", "-w", "/sys/fs/cgroup", defaultImage, "cat", "cpu.max")
+					"--cpu-period", "100000", "-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "cpu.max")
 				gomega.Expect(cpuMax).To(gomega.Equal("42000 100000"))
 			})
 
@@ -547,7 +547,7 @@ func Run(o *RunOption) {
 				//nolint: lll // the source of the CPUShares calculation formula
 				// Ref. https://github.com/google/cadvisor/blob/ce07bb28eadc18183df15ca5346293af6b020b33/integration/tests/api/docker_test.go#L216-L222
 				cpuWeight := command.StdoutStr(o.BaseOpt, "run", "--rm", "--cpu-shares", "2000",
-					"-w", "/sys/fs/cgroup", defaultImage, "cat", "cpu.weight")
+					"-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "cpu.weight")
 				gomega.Expect(cpuWeight).To(gomega.Equal("77"))
 			})
 
@@ -555,19 +555,19 @@ func Run(o *RunOption) {
 			ginkgo.When("--cpuset-cpus is used", func() {
 				ginkgo.It("should set CPUs in which to allow execution as cpu 1 with --cpuset-cpus=1", func() {
 					cpuSet := command.StdoutStr(o.BaseOpt, "run", "--cpuset-cpus", "1",
-						"-w", "/sys/fs/cgroup", defaultImage, "cat", "cpuset.cpus")
+						"-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "cpuset.cpus")
 					gomega.Expect(cpuSet).To(gomega.Equal("1"))
 				})
 
 				ginkgo.It("should set CPUs in which to allow execution as cpu 0-1 with --cpuset-cpus=0-1", func() {
 					cpuSet := command.StdoutStr(o.BaseOpt, "run", "--cpuset-cpus", "0-1",
-						"-w", "/sys/fs/cgroup", defaultImage, "cat", "cpuset.cpus")
+						"-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "cpuset.cpus")
 					gomega.Expect(cpuSet).To(gomega.Equal("0-1"))
 				})
 
 				ginkgo.It("should set CPUs in which to allow execution as cpu 0-1 with --cpuset-cpus=0,1", func() {
 					cpuSet := command.StdoutStr(o.BaseOpt, "run", "--cpuset-cpus", "0,1",
-						"-w", "/sys/fs/cgroup", defaultImage, "cat", "cpuset.cpus")
+						"-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "cpuset.cpus")
 					gomega.Expect(cpuSet).To(gomega.Equal("0-1"))
 				})
 			})
@@ -577,31 +577,31 @@ func Run(o *RunOption) {
 			// https://man7.org/linux/man-pages/man7/cpuset.7.html#WARNINGS
 			ginkgo.It("should set memory nodes (MEMs) in which to allow execution as memory node 0 with --cpuset-mems=0", func() {
 				cpuMems := command.StdoutStr(o.BaseOpt, "run", "--cpuset-mems", "0",
-					"-w", "/sys/fs/cgroup", defaultImage, "cat", "cpuset.mems")
+					"-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "cpuset.mems")
 				gomega.Expect(cpuMems).To(gomega.Equal("0"))
 			})
 
 			ginkgo.It("should set the memory limit with --memory", func() {
 				mem := command.StdoutStr(o.BaseOpt, "run", "--memory", "42m",
-					"-w", "/sys/fs/cgroup", defaultImage, "cat", "memory.max")
+					"-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "memory.max")
 				gomega.Expect(mem).To(gomega.Equal("44040192"))
 			})
 
 			ginkgo.It("should set the memory soft limit with --memory-reservation", func() {
 				mem := command.StdoutStr(o.BaseOpt, "run", "--memory-reservation", "6m",
-					"-w", "/sys/fs/cgroup", defaultImage, "cat", "memory.low")
+					"-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "memory.low")
 				gomega.Expect(mem).To(gomega.Equal("6291456"))
 			})
 
 			ginkgo.It("should set the amount of memory this container is allowed to swap to disk with --memory-swap", func() {
 				mem := command.StdoutStr(o.BaseOpt, "run", "--memory", "42m", "--memory-swap", "100m",
-					"-w", "/sys/fs/cgroup", defaultImage, "cat", "memory.max", "memory.swap.max")
+					"-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "memory.max", "memory.swap.max")
 				gomega.Expect(mem).To(gomega.Equal("44040192\n60817408"))
 			})
 
 			ginkgo.It("should set the container pids limit with --pids-limit", func() {
 				pidsLimit := command.StdoutStr(o.BaseOpt, "run", "--pids-limit", "42",
-					"-w", "/sys/fs/cgroup", defaultImage, "cat", "pids.max")
+					"-w", "/sys/fs/cgroup", localImages["defaultImage"], "cat", "pids.max")
 				gomega.Expect(pidsLimit).To(gomega.Equal("42"))
 			})
 
@@ -609,7 +609,7 @@ func Run(o *RunOption) {
 				// 100 is the minimum because finch VM runs rootless containerd inside.
 				testcases := []string{"100", "1000"}
 				for _, tc := range testcases {
-					score := command.StdoutStr(o.BaseOpt, "run", "--oom-score-adj", tc, defaultImage, "cat", "/proc/self/oom_score_adj")
+					score := command.StdoutStr(o.BaseOpt, "run", "--oom-score-adj", tc, localImages["defaultImage"], "cat", "/proc/self/oom_score_adj")
 					gomega.Expect(score).To(gomega.Equal(tc))
 				}
 			})
@@ -635,7 +635,7 @@ func Run(o *RunOption) {
 					"nobody:100":   {"uid=65534(nobody) gid=100(users)", "uid=65534(nobody) gid=100(users) groups=100(users)"},
 				}
 				for userStr, expected := range testCases {
-					output := command.StdoutStr(o.BaseOpt, "run", user, userStr, defaultImage, "id")
+					output := command.StdoutStr(o.BaseOpt, "run", user, userStr, localImages["defaultImage"], "id")
 					// TODO: Remove the Or operator after upgrading the nerdctl dependency to 1.2.1 to only match expected[1]
 					gomega.Expect(output).Should(gomega.Or(gomega.Equal(expected[0]), gomega.Equal(expected[1])))
 				}
@@ -674,7 +674,7 @@ func Run(o *RunOption) {
 					for _, group := range tc.groups {
 						args = append(args, "--group-add", group)
 					}
-					args = append(args, defaultImage, "id")
+					args = append(args, localImages["defaultImage"], "id")
 					output := command.StdoutStr(o.BaseOpt, args...)
 					// TODO: Remove the Or operator after upgrading the nerdctl dependency to 1.2.1 to only match tc.expected[1]
 					gomega.Expect(output).Should(gomega.Or(gomega.Equal(tc.expected[0]), gomega.Equal(tc.expected[1])))

--- a/tests/save.go
+++ b/tests/save.go
@@ -43,16 +43,16 @@ func Save(o *option.Option) {
 
 		ginkgo.Context("when the images exist", func() {
 			ginkgo.BeforeEach(func() {
-				pullImage(o, localImages["defaultImage"])
+				pullImage(o, localImages[defaultImage])
 			})
 
 			ginkgo.It("should save an image to stdout", func() {
-				stdout := command.New(o, "save", localImages["defaultImage"]).WithStdout(gbytes.NewBuffer()).Run().Out
+				stdout := command.New(o, "save", localImages[defaultImage]).WithStdout(gbytes.NewBuffer()).Run().Out
 				untar(stdout, tarFileContext)
 				manifestContent := readManifestContent(tarFileContext)
 
 				gomega.Expect(len(manifestContent)).Should(gomega.Equal(1))
-				gomega.Expect(manifestContent[0].RepoTags[0]).Should(gomega.Equal(localImages["defaultImage"]))
+				gomega.Expect(manifestContent[0].RepoTags[0]).Should(gomega.Equal(localImages[defaultImage]))
 
 				layersShouldExist(manifestContent[0].Layers, tarFileContext)
 			})
@@ -60,19 +60,19 @@ func Save(o *option.Option) {
 			for _, outputOption := range []string{"-o", "--output"} {
 				outputOption := outputOption
 				ginkgo.It(fmt.Sprintf("should save an image with %s option", outputOption), func() {
-					command.Run(o, "save", localImages["defaultImage"], outputOption, tarFilePath)
+					command.Run(o, "save", localImages[defaultImage], outputOption, tarFilePath)
 
 					untarFile(tarFilePath, tarFileContext)
 
 					manifestContent := readManifestContent(tarFileContext)
 					gomega.Expect(len(manifestContent)).Should(gomega.Equal(1))
-					gomega.Expect(manifestContent[0].RepoTags[0]).Should(gomega.Equal(localImages["defaultImage"]))
+					gomega.Expect(manifestContent[0].RepoTags[0]).Should(gomega.Equal(localImages[defaultImage]))
 					layersShouldExist(manifestContent[0].Layers, tarFileContext)
 				})
 
 				ginkgo.It(fmt.Sprintf("should save multiple images with %s option", outputOption), func() {
-					pullImage(o, localImages["olderAlpineImage"])
-					command.Run(o, "save", outputOption, tarFilePath, localImages["defaultImage"], localImages["olderAlpineImage"])
+					pullImage(o, localImages[olderAlpineImage])
+					command.Run(o, "save", outputOption, tarFilePath, localImages[defaultImage], localImages[olderAlpineImage])
 
 					untarFile(tarFilePath, tarFileContext)
 

--- a/tests/save.go
+++ b/tests/save.go
@@ -43,16 +43,16 @@ func Save(o *option.Option) {
 
 		ginkgo.Context("when the images exist", func() {
 			ginkgo.BeforeEach(func() {
-				pullImage(o, defaultImage)
+				pullImage(o, localImages["defaultImage"])
 			})
 
 			ginkgo.It("should save an image to stdout", func() {
-				stdout := command.New(o, "save", defaultImage).WithStdout(gbytes.NewBuffer()).Run().Out
+				stdout := command.New(o, "save", localImages["defaultImage"]).WithStdout(gbytes.NewBuffer()).Run().Out
 				untar(stdout, tarFileContext)
 				manifestContent := readManifestContent(tarFileContext)
 
 				gomega.Expect(len(manifestContent)).Should(gomega.Equal(1))
-				gomega.Expect(manifestContent[0].RepoTags[0]).Should(gomega.Equal(defaultImage))
+				gomega.Expect(manifestContent[0].RepoTags[0]).Should(gomega.Equal(localImages["defaultImage"]))
 
 				layersShouldExist(manifestContent[0].Layers, tarFileContext)
 			})
@@ -60,19 +60,19 @@ func Save(o *option.Option) {
 			for _, outputOption := range []string{"-o", "--output"} {
 				outputOption := outputOption
 				ginkgo.It(fmt.Sprintf("should save an image with %s option", outputOption), func() {
-					command.Run(o, "save", defaultImage, outputOption, tarFilePath)
+					command.Run(o, "save", localImages["defaultImage"], outputOption, tarFilePath)
 
 					untarFile(tarFilePath, tarFileContext)
 
 					manifestContent := readManifestContent(tarFileContext)
 					gomega.Expect(len(manifestContent)).Should(gomega.Equal(1))
-					gomega.Expect(manifestContent[0].RepoTags[0]).Should(gomega.Equal(defaultImage))
+					gomega.Expect(manifestContent[0].RepoTags[0]).Should(gomega.Equal(localImages["defaultImage"]))
 					layersShouldExist(manifestContent[0].Layers, tarFileContext)
 				})
 
 				ginkgo.It(fmt.Sprintf("should save multiple images with %s option", outputOption), func() {
-					pullImage(o, olderAlpineImage)
-					command.Run(o, "save", outputOption, tarFilePath, defaultImage, olderAlpineImage)
+					pullImage(o, localImages["olderAlpineImage"])
+					command.Run(o, "save", outputOption, tarFilePath, localImages["defaultImage"], localImages["olderAlpineImage"])
 
 					untarFile(tarFilePath, tarFileContext)
 

--- a/tests/start.go
+++ b/tests/start.go
@@ -24,7 +24,7 @@ func Start(o *option.Option) {
 		})
 
 		ginkgo.It("should start the container if it is in Exited status", func() {
-			command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "nc", "-l")
+			command.Run(o, "run", "-d", "--name", testContainerName, localImages[defaultImage], "nc", "-l")
 			containerShouldBeRunning(o, testContainerName)
 
 			command.Run(o, "stop", testContainerName)
@@ -37,7 +37,7 @@ func Start(o *option.Option) {
 		for _, attach := range []string{"--attach", "-a"} {
 			attach := attach
 			ginkgo.It(fmt.Sprintf("with %s flag, should start the container with stdout", attach), func() {
-				command.Run(o, "create", "--name", testContainerName, localImages["defaultImage"], "echo", "foo")
+				command.Run(o, "create", "--name", testContainerName, localImages[defaultImage], "echo", "foo")
 				output := command.StdoutStr(o, "start", attach, testContainerName)
 				gomega.Expect(output).To(gomega.Equal("foo"))
 			})

--- a/tests/start.go
+++ b/tests/start.go
@@ -24,7 +24,7 @@ func Start(o *option.Option) {
 		})
 
 		ginkgo.It("should start the container if it is in Exited status", func() {
-			command.Run(o, "run", "-d", "--name", testContainerName, defaultImage, "nc", "-l")
+			command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "nc", "-l")
 			containerShouldBeRunning(o, testContainerName)
 
 			command.Run(o, "stop", testContainerName)
@@ -37,7 +37,7 @@ func Start(o *option.Option) {
 		for _, attach := range []string{"--attach", "-a"} {
 			attach := attach
 			ginkgo.It(fmt.Sprintf("with %s flag, should start the container with stdout", attach), func() {
-				command.Run(o, "create", "--name", testContainerName, defaultImage, "echo", "foo")
+				command.Run(o, "create", "--name", testContainerName, localImages["defaultImage"], "echo", "foo")
 				output := command.StdoutStr(o, "start", attach, testContainerName)
 				gomega.Expect(output).To(gomega.Equal("foo"))
 			})

--- a/tests/stats.go
+++ b/tests/stats.go
@@ -25,7 +25,7 @@ func Stats(o *option.Option) {
 		// TODO: add test for streaming data
 		ginkgo.When("the container is running", func() {
 			ginkgo.BeforeEach(func() {
-				command.Run(o, "run", "-d", "--name", testContainerName, defaultImage, "sleep", "infinity")
+				command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "sleep", "infinity")
 			})
 
 			ginkgo.It("should disable streaming usage stats and print result with --no-stream flag", func() {

--- a/tests/stats.go
+++ b/tests/stats.go
@@ -25,7 +25,7 @@ func Stats(o *option.Option) {
 		// TODO: add test for streaming data
 		ginkgo.When("the container is running", func() {
 			ginkgo.BeforeEach(func() {
-				command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "sleep", "infinity")
+				command.Run(o, "run", "-d", "--name", testContainerName, localImages[defaultImage], "sleep", "infinity")
 			})
 
 			ginkgo.It("should disable streaming usage stats and print result with --no-stream flag", func() {

--- a/tests/stop.go
+++ b/tests/stop.go
@@ -24,7 +24,7 @@ func Stop(o *option.Option) {
 		})
 
 		ginkgo.It("should stop the container if the container is running", func() {
-			command.Run(o, "run", "-d", "--name", testContainerName, defaultImage, "nc", "-l")
+			command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "nc", "-l")
 			containerShouldBeRunning(o, testContainerName)
 
 			command.Run(o, "stop", testContainerName)
@@ -36,7 +36,7 @@ func Stop(o *option.Option) {
 			ginkgo.It(fmt.Sprintf("should stop running container within specified time by %s flag", timeFlag), func() {
 				// With PID=1, `sleep infinity` does not exit due to receiving a SIGTERM, which is sent by the stop command.
 				// Ref. https://superuser.com/a/1299463/730265
-				command.Run(o, "run", "-d", "--name", testContainerName, defaultImage, "sleep", "infinity")
+				command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "sleep", "infinity")
 				gomega.Expect(command.StdoutStr(o, "exec", testContainerName, "echo", "foo")).To(gomega.Equal("foo"))
 				startTime := time.Now()
 				command.Run(o, "stop", "-t", "1", testContainerName)

--- a/tests/stop.go
+++ b/tests/stop.go
@@ -24,7 +24,7 @@ func Stop(o *option.Option) {
 		})
 
 		ginkgo.It("should stop the container if the container is running", func() {
-			command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "nc", "-l")
+			command.Run(o, "run", "-d", "--name", testContainerName, localImages[defaultImage], "nc", "-l")
 			containerShouldBeRunning(o, testContainerName)
 
 			command.Run(o, "stop", testContainerName)
@@ -36,7 +36,7 @@ func Stop(o *option.Option) {
 			ginkgo.It(fmt.Sprintf("should stop running container within specified time by %s flag", timeFlag), func() {
 				// With PID=1, `sleep infinity` does not exit due to receiving a SIGTERM, which is sent by the stop command.
 				// Ref. https://superuser.com/a/1299463/730265
-				command.Run(o, "run", "-d", "--name", testContainerName, localImages["defaultImage"], "sleep", "infinity")
+				command.Run(o, "run", "-d", "--name", testContainerName, localImages[defaultImage], "sleep", "infinity")
 				gomega.Expect(command.StdoutStr(o, "exec", testContainerName, "echo", "foo")).To(gomega.Equal("foo"))
 				startTime := time.Now()
 				command.Run(o, "stop", "-t", "1", testContainerName)

--- a/tests/tag.go
+++ b/tests/tag.go
@@ -21,10 +21,10 @@ func Tag(o *option.Option) {
 			command.RemoveAll(o)
 		})
 		ginkgo.It("should tag an image when the image exists", func() {
-			pullImage(o, localImages["defaultImage"])
+			pullImage(o, localImages[defaultImage])
 
-			command.Run(o, "tag", localImages["defaultImage"], testImageName)
-			defaultImageID := command.Stdout(o, "images", "--quiet", "--no-trunc", localImages["defaultImage"])
+			command.Run(o, "tag", localImages[defaultImage], testImageName)
+			defaultImageID := command.Stdout(o, "images", "--quiet", "--no-trunc", localImages[defaultImage])
 			taggedImageID := command.Stdout(o, "images", "--quiet", "--no-trunc", testImageName)
 			gomega.Expect(taggedImageID).ShouldNot(gomega.BeEmpty())
 			gomega.Expect(taggedImageID).To(gomega.Equal(defaultImageID))

--- a/tests/tag.go
+++ b/tests/tag.go
@@ -21,10 +21,10 @@ func Tag(o *option.Option) {
 			command.RemoveAll(o)
 		})
 		ginkgo.It("should tag an image when the image exists", func() {
-			pullImage(o, defaultImage)
+			pullImage(o, localImages["defaultImage"])
 
-			command.Run(o, "tag", defaultImage, testImageName)
-			defaultImageID := command.Stdout(o, "images", "--quiet", "--no-trunc", defaultImage)
+			command.Run(o, "tag", localImages["defaultImage"], testImageName)
+			defaultImageID := command.Stdout(o, "images", "--quiet", "--no-trunc", localImages["defaultImage"])
 			taggedImageID := command.Stdout(o, "images", "--quiet", "--no-trunc", testImageName)
 			gomega.Expect(taggedImageID).ShouldNot(gomega.BeEmpty())
 			gomega.Expect(taggedImageID).To(gomega.Equal(defaultImageID))

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -42,11 +42,20 @@ const (
 	testNetwork              = "test-network"
 )
 
-var localImages = map[string]string{
-	"defaultImage":      alpineImage,
-	"olderAlpineImage":  "public.ecr.aws/docker/library/alpine:3.13",
-	"amazonLinux2Image": "public.ecr.aws/amazonlinux/amazonlinux:2",
-	"nginxImage":        "public.ecr.aws/docker/library/nginx:latest",
+type localImage string
+
+const (
+	defaultImage      localImage = "defaultImage"
+	olderAlpineImage  localImage = "olderAlpineImage"
+	amazonLinux2Image localImage = "amazonLinux2Image"
+	nginxImage        localImage = "nginxImage"
+)
+
+var localImages = map[localImage]string{
+	defaultImage:      alpineImage,
+	olderAlpineImage:  "public.ecr.aws/docker/library/alpine:3.13",
+	amazonLinux2Image: "public.ecr.aws/amazonlinux/amazonlinux:2",
+	nginxImage:        "public.ecr.aws/docker/library/nginx:latest",
 }
 
 // CGMode is the cgroups mode of the host system.
@@ -192,7 +201,7 @@ func fileShouldNotExistInContainer(o *option.Option, containerName, path string)
 func buildImage(o *option.Option, imageName string) {
 	dockerfile := fmt.Sprintf(`FROM %s
 		CMD ["echo", "finch-test-dummy-output"]
-		`, localImages["defaultImage"])
+		`, localImages[defaultImage])
 	buildContext := ffs.CreateBuildContext(dockerfile)
 	ginkgo.DeferCleanup(os.RemoveAll, buildContext)
 	command.Run(o, "build", "-q", "-t", imageName, buildContext)

--- a/tests/volume_create.go
+++ b/tests/volume_create.go
@@ -30,8 +30,8 @@ func VolumeCreate(o *option.Option) {
 
 		ginkgo.It("data in volume should be shared between containers", func() {
 			command.Run(o, "volume", "create", testVolumeName)
-			command.Run(o, "run", "-v", fmt.Sprintf("%s:/tmp", testVolumeName), defaultImage, "sh", "-c", "echo foo > /tmp/test.txt")
-			output := command.StdoutStr(o, "run", "-v", fmt.Sprintf("%s:/tmp", testVolumeName), defaultImage, "cat", "/tmp/test.txt")
+			command.Run(o, "run", "-v", fmt.Sprintf("%s:/tmp", testVolumeName), localImages["defaultImage"], "sh", "-c", "echo foo > /tmp/test.txt")
+			output := command.StdoutStr(o, "run", "-v", fmt.Sprintf("%s:/tmp", testVolumeName), localImages["defaultImage"], "cat", "/tmp/test.txt")
 			gomega.Expect(output).Should(gomega.Equal("foo"))
 		})
 

--- a/tests/volume_create.go
+++ b/tests/volume_create.go
@@ -30,8 +30,23 @@ func VolumeCreate(o *option.Option) {
 
 		ginkgo.It("data in volume should be shared between containers", func() {
 			command.Run(o, "volume", "create", testVolumeName)
-			command.Run(o, "run", "-v", fmt.Sprintf("%s:/tmp", testVolumeName), localImages["defaultImage"], "sh", "-c", "echo foo > /tmp/test.txt")
-			output := command.StdoutStr(o, "run", "-v", fmt.Sprintf("%s:/tmp", testVolumeName), localImages["defaultImage"], "cat", "/tmp/test.txt")
+			command.Run(
+				o,
+				"run",
+				"-v",
+				fmt.Sprintf("%s:/tmp", testVolumeName),
+				localImages[defaultImage],
+				"sh", "-c", "echo foo > /tmp/test.txt",
+			)
+			output := command.StdoutStr(
+				o,
+				"run",
+				"-v",
+				fmt.Sprintf("%s:/tmp", testVolumeName),
+				localImages[defaultImage],
+				"cat",
+				"/tmp/test.txt",
+			)
 			gomega.Expect(output).Should(gomega.Equal("foo"))
 		})
 

--- a/tests/volume_prune.go
+++ b/tests/volume_prune.go
@@ -23,7 +23,7 @@ func VolumePrune(o *option.Option) {
 		})
 
 		ginkgo.It("should not remove a volume if it is used by a container", func() {
-			command.Run(o, "run", "-v", fmt.Sprintf("%s:/tmp", testVolumeName), "--name", testContainerName, localImages["defaultImage"])
+			command.Run(o, "run", "-v", fmt.Sprintf("%s:/tmp", testVolumeName), "--name", testContainerName, localImages[defaultImage])
 			command.Run(o, "volume", "prune", "--force", "--all")
 			volumeShouldExist(o, testVolumeName)
 		})

--- a/tests/volume_prune.go
+++ b/tests/volume_prune.go
@@ -23,7 +23,7 @@ func VolumePrune(o *option.Option) {
 		})
 
 		ginkgo.It("should not remove a volume if it is used by a container", func() {
-			command.Run(o, "run", "-v", fmt.Sprintf("%s:/tmp", testVolumeName), "--name", testContainerName, defaultImage)
+			command.Run(o, "run", "-v", fmt.Sprintf("%s:/tmp", testVolumeName), "--name", testContainerName, localImages["defaultImage"])
 			command.Run(o, "volume", "prune", "--force", "--all")
 			volumeShouldExist(o, testVolumeName)
 		})

--- a/tests/volume_rm.go
+++ b/tests/volume_rm.go
@@ -45,7 +45,7 @@ func VolumeRm(o *option.Option) {
 		ginkgo.When("a volume is used by a container", func() {
 			ginkgo.BeforeEach(func() {
 				command.Run(o, "volume", "create", testVolumeName)
-				command.Run(o, "run", "-v", fmt.Sprintf("%s:/tmp", testVolumeName), defaultImage)
+				command.Run(o, "run", "-v", fmt.Sprintf("%s:/tmp", testVolumeName), localImages["defaultImage"])
 			})
 
 			// It's expected that `volume rm` can't remove the volume that is referenced to a container despite the container status.

--- a/tests/volume_rm.go
+++ b/tests/volume_rm.go
@@ -45,7 +45,7 @@ func VolumeRm(o *option.Option) {
 		ginkgo.When("a volume is used by a container", func() {
 			ginkgo.BeforeEach(func() {
 				command.Run(o, "volume", "create", testVolumeName)
-				command.Run(o, "run", "-v", fmt.Sprintf("%s:/tmp", testVolumeName), localImages["defaultImage"])
+				command.Run(o, "run", "-v", fmt.Sprintf("%s:/tmp", testVolumeName), localImages[defaultImage])
 			})
 
 			// It's expected that `volume rm` can't remove the volume that is referenced to a container despite the container status.


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Pre-fetches all images before running tests
    - The bulk of the change is in [`tests/tests.go`](https://github.com/runfinch/common-tests/compare/main...pendo324:common-tests:pre-fetch-images?expand=1#diff-a61afa8338f0442d1308258f7320c1a4a4698b432ac42d23bca256980f16f75a)
    - This drastically reduces the possibility of tests timing out due to external network download speed

There might be a better way to implement this, this was just the first way I thought of. Please post suggestions if you have any

*Testing done:*
- Tested locally against latest Finch main branch


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.