### PR TITLE
fix: use of uninitialized global variable

### DIFF
--- a/tests/compose_logs.go
+++ b/tests/compose_logs.go
@@ -19,12 +19,14 @@ import (
 func ComposeLogs(o *option.Option) {
 	services := []string{"svc1_compose_logs", "svc2_compose_logs"}
 	containerNames := []string{"container1_compose_logs", "container2_compose_logs"}
-	imageNames := []string{localImages[defaultImage], localImages[defaultImage]}
 
 	ginkgo.Describe("Compose logs command", func() {
 		var buildContext string
 		var composeFilePath string
+		var imageNames []string
+
 		ginkgo.BeforeEach(func() {
+			imageNames = []string{localImages[defaultImage], localImages[defaultImage]}
 			command.RemoveAll(o)
 			buildContext, composeFilePath = createComposeYmlForLogsCmd(services, imageNames, containerNames)
 			ginkgo.DeferCleanup(os.RemoveAll, buildContext)

--- a/tests/compose_ps.go
+++ b/tests/compose_ps.go
@@ -19,12 +19,14 @@ import (
 func ComposePs(o *option.Option) {
 	services := []string{"svc1_compose_ps", "svc2_compose_ps"}
 	containerNames := []string{"container1_compose_ps", "container2_compose_ps"}
-	imageNames := []string{localImages[defaultImage], localImages[defaultImage]}
 
 	ginkgo.Describe("Compose ps command", func() {
 		var composeContext string
 		var composeFilePath string
+		var imageNames []string
+
 		ginkgo.BeforeEach(func() {
+			imageNames = []string{localImages[defaultImage], localImages[defaultImage]}
 			command.RemoveAll(o)
 			composeContext, composeFilePath = createComposeYmlForPsCmd(services, imageNames, containerNames)
 			ginkgo.DeferCleanup(os.RemoveAll, composeContext)

--- a/tests/compose_pull.go
+++ b/tests/compose_pull.go
@@ -18,11 +18,13 @@ import (
 // ComposePull tests functionality of `compose pull` command.
 func ComposePull(o *option.Option) {
 	services := []string{"svc1_compose_pull", "svc2_compose_pull"}
-	imageNames := []string{localImages[defaultImage], localImages[olderAlpineImage]}
 	ginkgo.Describe("Compose pull command", func() {
 		var composeContext string
 		var composeFilePath string
+		var imageNames []string
+
 		ginkgo.BeforeEach(func() {
+			imageNames = []string{localImages[defaultImage], localImages[olderAlpineImage]}
 			command.RemoveAll(o)
 			composeContext, composeFilePath = createComposeYmlForPullCmd(services, imageNames)
 			ginkgo.DeferCleanup(os.RemoveAll, composeContext)

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -98,7 +98,9 @@ func SetupLocalRegistry(o *option.Option) {
 		// split image tag according to spec
 		// https://github.com/distribution/distribution/blob/d0deff9cd6c2b8c82c6f3d1c713af51df099d07b/reference/reference.go
 		_, name, _ := strings.Cut(ref, "/")
-		command.Run(o, "pull", ref)
+		// allow up to a minute for remote pulls to account for external network
+		// latency/throughput issues or throttling (default is 10 seconds)
+		command.New(o, "pull", ref).WithTimeoutInSeconds(60).Run()
 		localRef := fmt.Sprintf("localhost:%d/%s", hostPort, name)
 		command.Run(o, "tag", ref, localRef)
 		command.Run(o, "push", localRef)


### PR DESCRIPTION
Issue #, if available: https://github.com/runfinch/finch/actions/runs/8427176493/job/23080891806#step:10:2784

*Description of changes:*
- Fixes issue where some tests were using an uninitialized global variable since the assignment statements were executed before ginkgo's `SynchronizedBeforeSuite`, which actually populates `localImages`
    - Somehow I didn't catch this when I did my local testing before the last release, but I have confirmed this change fixes it locally
- Also added a trivial change to allow remote pulls in `SetupLocalRegistry` to take up to 60 seconds

*Testing done:*
- Local testing


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.