### PR TITLE
fix: image pull retry logic

### DIFF
--- a/tests/tests.go
+++ b/tests/tests.go
@@ -108,7 +108,7 @@ func SetupLocalRegistry(o *option.Option) {
 		// retry pull for 3 times
 		var session *gexec.Session
 		for i := 0; i < retryPull; i++ {
-			session = command.New(o, "pull", ref).WithTimeoutInSeconds(30).WithoutSuccessfulExit().Run()
+			session = command.New(o, "pull", ref).WithTimeoutInSeconds(30).WithoutCheckingExitCode().Run()
 			if session.ExitCode() == 0 {
 				break
 			}


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Earlier push had a bug as we want to check logic for exit code outside for image pull

*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.