### PR TITLE
fix: add a delay for system event monitoring to start before pull completes as the run commands are async

### DIFF
--- a/tests/events.go
+++ b/tests/events.go
@@ -28,8 +28,13 @@ func Events(o *option.Option) {
 		ginkgo.It("should get real time events from command", func() {
 			session := command.RunWithoutWait(o, "system", "events")
 			defer session.Kill()
+
+			// Give time for the system events to be running and monitoring before pull is called.
+			time.Sleep(5 * time.Second)
+
 			gomega.Expect(session.Out.Contents()).Should(gomega.BeEmpty())
 			command.Run(o, "pull", localImages[defaultImage])
+
 			// allow propagation time
 			gomega.Eventually(func(session *gexec.Session) string {
 				return strings.TrimSpace(string(session.Out.Contents()))


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
This test fails around 50% of time in windows
```
should get real time events from command
```
adding the delay ensures system event process has started before the commands it monitors are running. This is a async call so this fix is required.

*Testing done:*



- [ x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.