### PR TITLE
test: Add an e2e test for the COMPOSE_FILE environment variable in fi…

### DIFF
--- a/option/option.go
+++ b/option/option.go
@@ -6,6 +6,7 @@ package option
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -53,8 +54,9 @@ func (o *Option) NewCmd(args ...string) *exec.Cmd {
 }
 
 // UpdateEnv updates the environment variable for the key name of the input.
-func (o *Option) UpdateEnv(env string) {
-	if i, exists := containsEnv(o.env, env); exists {
+func (o *Option) UpdateEnv(envKey, envValue string) {
+	env := fmt.Sprintf("%s=%s", envKey, envValue)
+	if i, exists := containsEnv(o.env, envKey); exists {
 		o.env[i] = env
 	} else {
 		o.env = append(o.env, env)
@@ -62,18 +64,16 @@ func (o *Option) UpdateEnv(env string) {
 }
 
 // DeleteEnv deletes the environment variable for the key name of the input.
-func (o *Option) DeleteEnv(env string) {
-	if i, exists := containsEnv(o.env, env); exists {
+func (o *Option) DeleteEnv(envKey string) {
+	if i, exists := containsEnv(o.env, envKey); exists {
 		o.env = append(o.env[:i], o.env[i+1:]...)
 	}
 }
 
 // containsEnv determines whether an environment variable exists.
-func containsEnv(envs []string, targetEnv string) (int, bool) {
+func containsEnv(envs []string, targetEnvKey string) (int, bool) {
 	for i, env := range envs {
-		envKey := strings.Split(env, "=")[0]
-		targetEnvKey := strings.Split(targetEnv, "=")[0]
-		if envKey == targetEnvKey {
+		if strings.Split(env, "=")[0] == targetEnvKey {
 			return i, true
 		}
 	}

--- a/option/option.go
+++ b/option/option.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // Option customizes how tests are run.
@@ -49,4 +50,33 @@ func (o *Option) NewCmd(args ...string) *exec.Cmd {
 	cmd := exec.Command(cmdName, cmdArgs...)  //nolint:gosec // G204 is not an issue because cmdName is fully controlled by the user.
 	cmd.Env = append(os.Environ(), o.env...)
 	return cmd
+}
+
+// UpdateEnv updates the environment variable for the key name of the input.
+func (o *Option) UpdateEnv(env string) {
+	if i, exists := containsEnv(o.env, env); exists {
+		o.env[i] = env
+	} else {
+		o.env = append(o.env, env)
+	}
+}
+
+// DeleteEnv deletes the environment variable for the key name of the input.
+func (o *Option) DeleteEnv(env string) {
+	if i, exists := containsEnv(o.env, env); exists {
+		o.env = append(o.env[:i], o.env[i+1:]...)
+	}
+}
+
+// containsEnv determines whether an environment variable exists.
+func containsEnv(envs []string, targetEnv string) (int, bool) {
+	for i, env := range envs {
+		envKey := strings.Split(env, "=")[0]
+		targetEnvKey := strings.Split(targetEnv, "=")[0]
+		if envKey == targetEnvKey {
+			return i, true
+		}
+	}
+
+	return -1, false
 }

--- a/tests/compose_build.go
+++ b/tests/compose_build.go
@@ -44,6 +44,22 @@ func ComposeBuild(o *option.Option) {
 			gomega.Expect(output).Should(gomega.Equal("Compose build test"))
 		})
 
+		ginkgo.It("should build services defined in the compose file specified by the COMPOSE_FILE environment variable", func() {
+			envValue := fmt.Sprintf("COMPOSE_FILE=%s", composeFilePath)
+			o.UpdateEnv(envValue)
+
+			command.Run(o, "compose", "build")
+
+			imageList := command.GetAllImageNames(o)
+			gomega.Expect(imageList).Should(gomega.ContainElement(gomega.HaveSuffix(imageSuffix[0])))
+			gomega.Expect(imageList).Should(gomega.ContainElement(gomega.HaveSuffix(imageSuffix[1])))
+			// The built image should print 'Compose build test' when run.
+			output := command.StdoutStr(o, "run", localImages[defaultImage])
+			gomega.Expect(output).Should(gomega.Equal("Compose build test"))
+
+			o.DeleteEnv(envValue)
+		})
+
 		ginkgo.It("should output progress in plain text format", func() {
 			composeBuildOutput := command.StderrStr(o, "compose", "build", "--progress",
 				"plain", "--no-cache", "--file", composeFilePath)

--- a/tests/compose_build.go
+++ b/tests/compose_build.go
@@ -45,8 +45,8 @@ func ComposeBuild(o *option.Option) {
 		})
 
 		ginkgo.It("should build services defined in the compose file specified by the COMPOSE_FILE environment variable", func() {
-			envValue := fmt.Sprintf("COMPOSE_FILE=%s", composeFilePath)
-			o.UpdateEnv(envValue)
+			envKey := "COMPOSE_FILE"
+			o.UpdateEnv(envKey, composeFilePath)
 
 			command.Run(o, "compose", "build")
 
@@ -57,7 +57,7 @@ func ComposeBuild(o *option.Option) {
 			output := command.StdoutStr(o, "run", localImages[defaultImage])
 			gomega.Expect(output).Should(gomega.Equal("Compose build test"))
 
-			o.DeleteEnv(envValue)
+			o.DeleteEnv(envKey)
 		})
 
 		ginkgo.It("should output progress in plain text format", func() {


### PR DESCRIPTION
…nch compose command

The following pull request attempts to modify finch compose command to allow the COMPOSE_FILE environment variable.

- https://github.com/runfinch/finch/pull/994

Therefore, this fix adds an e2e test to run finch compose command with the COMPOSE_FILE environment variable.

Issue #, if available: N/A

*Description of changes:* The details are described in this commit message.

*Testing done:* Yes


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.