### PR TITLE
feat: Add test to check exit code

### DIFF
--- a/tests/run.go
+++ b/tests/run.go
@@ -67,6 +67,14 @@ func Run(o *RunOption) {
 			})
 		})
 
+		ginkgo.It("container should exit with exit code in case of an error", func() {
+			exitCode := 10
+			cmd := fmt.Sprintf("exit %d", exitCode)
+			session := command.RunWithoutSuccessfulExit(o.BaseOpt, "run", "--rm", "--name", testContainerName,
+				localImages[defaultImage], "sh", "-c", cmd)
+			gomega.Expect(session.ExitCode()).To(gomega.Equal(exitCode))
+		})
+
 		ginkgo.It("with --rm flag, container should be removed when it exits", func() {
 			command.Run(o.BaseOpt, "run", "--rm", "--name", testContainerName, localImages[defaultImage])
 			err := containerShouldNotExist(o.BaseOpt, testContainerName)


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Add a test to check for exit code.
Currently for all erroneous exit we exit with exit code 1. With the new approach we would exit with the correct exit code specified in the error. This test is added to validate the change. 
Refer: https://github.com/runfinch/finch/pull/1068

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.