### PR TITLE
ci: bump golangci-lint to v1.62.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
           # Pin the version in case all the builds start to fail at the same time.
           # There may not be an automatic way (e.g., dependabot) to update a specific parameter of a Github Action,
           # so we will just update it manually whenever it makes sense (e.g., a feature that we want is added).
-          version: v1.51.2
+          version: v1.62.2
           args: --fix=false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ linters-settings:
   goheader:
     template-path: copyright_header
   goimports:
-    local-prefixes: github.com/runfinch/tests
+    local-prefixes: github.com/runfinch/common-tests
   gosec:
     config:
       G306: "0o644"
@@ -23,9 +23,9 @@ linters-settings:
     checks: ["all", "-ST1003"]
 linters:
   enable:
+    - copyloopvar
     - errname
     - errorlint
-    - exportloopref
     - forcetypeassert
     - gocritic
     - godot

--- a/command/remove.go
+++ b/command/remove.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"github.com/onsi/ginkgo/v2"
+
 	"github.com/runfinch/common-tests/option"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/runfinch/common-tests
 
-go 1.20
+go 1.22
 
 require (
 	github.com/onsi/ginkgo/v2 v2.20.0

--- a/tests/build.go
+++ b/tests/build.go
@@ -40,7 +40,6 @@ func Build(o *option.Option) {
 			})
 
 			for _, tag := range []string{"-t", "--tag"} {
-				tag := tag
 				ginkgo.It(fmt.Sprintf("build basic alpine image with %s option", tag), func() {
 					command.Run(o, "build", tag, testImageName, buildContext)
 					imageShouldExist(o, testImageName)
@@ -57,7 +56,6 @@ func Build(o *option.Option) {
 				})
 
 				for _, file := range []string{"-f", "--file"} {
-					file := file
 					ginkgo.It(fmt.Sprintf("build an image with %s option", file), func() {
 						stdErr := command.Stderr(o, "build", "--no-cache", file, dockerFilePath, buildContext)
 						gomega.Expect(stdErr).Should(gomega.ContainSubstring("built from AnotherDockerfile"))
@@ -170,7 +168,6 @@ func Build(o *option.Option) {
 				}
 
 				for _, test := range negativeTests {
-					test := test
 					ginkgo.It("should not successfully build a container", func() {
 						dockerFilePath := filepath.Join(buildContext, test.fileName)
 						ffs.WriteFile(dockerFilePath, test.instructions)

--- a/tests/compose_down.go
+++ b/tests/compose_down.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+
 	"github.com/runfinch/common-tests/command"
 	"github.com/runfinch/common-tests/ffs"
 	"github.com/runfinch/common-tests/option"
@@ -46,7 +47,6 @@ func ComposeDown(o *option.Option) {
 		})
 
 		for _, volumes := range []string{"-v", "--volumes"} {
-			volumes := volumes
 			ginkgo.It(fmt.Sprintf("should stop compose services and delete volumes by specifying %s flag", volumes), func() {
 				volumes := volumes
 				output := command.StdoutStr(o, "compose", "down", volumes, "--file", composeFilePath)

--- a/tests/compose_kill.go
+++ b/tests/compose_kill.go
@@ -44,9 +44,7 @@ func ComposeKill(o *option.Option) {
 		// With PID=1, `sleep infinity` will only exit when receiving SIGKILL. Default signal for kill is SIGKILL.
 		// https://stackoverflow.com/questions/45148381/why-cant-i-ctrl-c-a-sleep-infinity-in-docker-when-it-runs-as-pid-1
 		for _, signal := range []string{"-s", "--signal"} {
-			signal := signal
 			for _, term := range []string{"SIGTERM", "TERM"} {
-				term := term
 				ginkgo.It(fmt.Sprintf("should not kill running containers with %s %s", signal, term), func() {
 					command.Run(o, "compose", "kill", signal, term, "--file", composeFilePath)
 					containerShouldBeRunning(o, containerNames...)

--- a/tests/compose_logs.go
+++ b/tests/compose_logs.go
@@ -65,7 +65,6 @@ func ComposeLogs(o *option.Option) {
 		})
 
 		for _, tFlag := range []string{"-t", "--timestamps"} {
-			tFlag := tFlag
 			ginkgo.It(fmt.Sprintf("should show the logs with timestamp with no prefixes and no color [flag %s]", tFlag), func() {
 				// Log format: YYYY-MM-DDThh:mm:ss.000000000Z LOG MSG
 				timestampMatcher := gomega.MatchRegexp("^[0-9]{1,4}-[0-9]{1,2}-[0-9]{1,2}T[0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2}.*")

--- a/tests/cp.go
+++ b/tests/cp.go
@@ -56,7 +56,6 @@ func Cp(o *option.Option) {
 			})
 
 			for _, link := range []string{"-L", "--follow-link"} {
-				link := link
 				ginkgo.It(fmt.Sprintf("with %s flag, should be able to copy file from host to container and follow symbolic link",
 					link), func() {
 					path := ffs.CreateTempFile(filename, content)

--- a/tests/exec.go
+++ b/tests/exec.go
@@ -39,7 +39,6 @@ func Exec(o *option.Option) {
 			})
 
 			for _, interactive := range []string{"-i", "--interactive", "-i=true", "--interactive=true"} {
-				interactive := interactive
 				ginkgo.It(fmt.Sprintf("should output string by piping if %s flag keeps STDIN open", interactive), func() {
 					want := []byte("hello")
 					got := command.New(o, "exec", interactive, testContainerName, "cat").
@@ -49,7 +48,6 @@ func Exec(o *option.Option) {
 			}
 
 			for _, detach := range []string{"-d", "--detach", "-d=true", "--detach=true"} {
-				detach := detach
 				ginkgo.It(fmt.Sprintf("should execute command in detached mode with %s flag", detach), func() {
 					command.Run(o, "exec", detach, testContainerName, "nc", "-l")
 					processes := command.StdoutStr(o, "exec", testContainerName, "ps", "aux")
@@ -58,7 +56,6 @@ func Exec(o *option.Option) {
 			}
 
 			for _, workDir := range []string{"-w", "--workdir"} {
-				workDir := workDir
 				ginkgo.It(fmt.Sprintf("should execute command under directory specified by %s flag", workDir), func() {
 					dir := "/tmp"
 					output := command.StdoutStr(o, "exec", workDir, dir, testContainerName, "pwd")
@@ -67,7 +64,6 @@ func Exec(o *option.Option) {
 			}
 
 			for _, env := range []string{"-e", "--env"} {
-				env := env
 				ginkgo.It(fmt.Sprintf("should set the environment variable with %s flag", env), func() {
 					const envPair = "ENV=1"
 					lines := command.StdoutAsLines(o, "exec", env, envPair, testContainerName, "env")
@@ -85,7 +81,6 @@ func Exec(o *option.Option) {
 			})
 
 			for _, privilegedFlag := range []string{"--privileged", "--privileged=true"} {
-				privilegedFlag := privilegedFlag
 				ginkgo.It(fmt.Sprintf("should execute command in privileged mode with %s flag", privilegedFlag), func() {
 					command.RunWithoutSuccessfulExit(o, "exec", testContainerName, "ip", "link", "add", "dummy1", "type", "dummy")
 					command.Run(o, "exec", privilegedFlag, testContainerName, "ip", "link", "add", "dummy1", "type", "dummy")
@@ -95,7 +90,6 @@ func Exec(o *option.Option) {
 			}
 
 			for _, user := range []string{"-u", "--user"} {
-				user := user
 				ginkgo.It(fmt.Sprintf("should output user id according to user name specified by %s flag", user), func() {
 					testCases := map[string][]string{
 						"1000":       {"uid=1000 gid=0(root)", "uid=1000 gid=0(root) groups=0(root)"},

--- a/tests/image_history.go
+++ b/tests/image_history.go
@@ -34,7 +34,6 @@ func ImageHistory(o *option.Option) {
 		})
 
 		for _, quiet := range []string{"-q", "--quiet"} {
-			quiet := quiet
 			ginkgo.It(fmt.Sprintf("should only display snapshot ID with %s flag", quiet), func() {
 				ids := removeMissingID(command.StdoutAsLines(o, "image", "history", quiet, localImages[defaultImage]))
 				gomega.Expect(ids).Should(gomega.HaveEach(gomega.MatchRegexp(sha256RegexFull)))

--- a/tests/image_prune.go
+++ b/tests/image_prune.go
@@ -40,7 +40,6 @@ func ImagePrune(o *option.Option) {
 		})
 
 		for _, force := range []string{"-f", "--force"} {
-			force := force
 			ginkgo.It(fmt.Sprintf("with %s flag, should remove unused images without prompting a confirmation", force), func() {
 				imageShouldExist(o, localImages[defaultImage])
 				command.Run(o, "image", "prune", "-a", "-f")

--- a/tests/kill.go
+++ b/tests/kill.go
@@ -35,11 +35,9 @@ func Kill(o *option.Option) {
 			})
 
 			for _, signal := range []string{"-s", "--signal"} {
-				signal := signal
 				// With PID=1, `sleep infinity` will only exit when receiving SIGKILL. Default signal for kill is SIGKILL.
 				// https://stackoverflow.com/questions/45148381/why-cant-i-ctrl-c-a-sleep-infinity-in-docker-when-it-runs-as-pid-1
 				for _, term := range []string{"SIGTERM", "TERM"} {
-					term := term
 					ginkgo.It(fmt.Sprintf("should not kill the running container with %s %s", signal, term), func() {
 						containerShouldBeRunning(o, testContainerName)
 						command.Run(o, "kill", signal, term, testContainerName)

--- a/tests/load.go
+++ b/tests/load.go
@@ -31,7 +31,6 @@ func Load(o *option.Option) {
 		// TODO: add test for input redirection sign
 		// REF issue: https://github.com/lima-vm/lima/issues/1078
 		for _, inputOption := range []string{"-i", "--input"} {
-			inputOption := inputOption
 			ginkgo.It(fmt.Sprintf("should load an image with %s option", inputOption), func() {
 				command.Run(o, "save", "-o", tarFilePath, localImages[defaultImage])
 

--- a/tests/login.go
+++ b/tests/login.go
@@ -60,7 +60,6 @@ func Login(o *option.Option) {
 			})
 			for _, username := range []string{"-u", "--username"} {
 				for _, password := range []string{"-p", "--password"} {
-					username, password := username, password
 					ginkgo.It("should push an image after successfully logging in the registry with a correct credential", func() {
 						command.Run(o, "login", registry, username, testUser, password, testPassword)
 						ginkgo.DeferCleanup(func() {

--- a/tests/logs.go
+++ b/tests/logs.go
@@ -40,7 +40,6 @@ func Logs(o *option.Option) {
 			})
 
 			for _, timestamps := range []string{"-t", "--timestamps"} {
-				timestamps := timestamps
 				ginkgo.It(fmt.Sprintf("should include timestamp with %s flag", timestamps), func() {
 					output := command.StdoutStr(o, "logs", timestamps, testContainerName)
 					// `logs --timestamps` command will add an RFC3339Nano timestamp,
@@ -76,7 +75,6 @@ func Logs(o *option.Option) {
 			})
 
 			for _, tail := range []string{"-n", "--tail"} {
-				tail := tail
 				ginkgo.It(fmt.Sprintf("should show number of lines from end of the logs with %s flag", tail), func() {
 					expectedOutput := fmt.Sprintf("%s\n%s", foo, bar)
 					output := command.StdoutStr(o, "logs", tail, "1", testContainerName)
@@ -93,7 +91,6 @@ func Logs(o *option.Option) {
 			})
 
 			for _, follow := range []string{"-f", "--follow"} {
-				follow := follow
 				ginkgo.It(fmt.Sprintf("should follow log output with %s flag", follow), func() {
 					const newLog = "hello"
 					session := command.RunWithoutWait(o, "logs", follow, testContainerName)

--- a/tests/network_create.go
+++ b/tests/network_create.go
@@ -78,9 +78,7 @@ func NetworkCreate(o *option.Option) {
 		})
 
 		for _, driverFlag := range []string{"-d", "--driver"} {
-			driverFlag := driverFlag
 			for _, driver := range []string{"macvlan", "ipvlan"} {
-				driver := driver
 				ginkgo.It(fmt.Sprintf("should create %s network with %s flag", driver, driverFlag), func() {
 					command.Run(o, "network", "create", driverFlag, driver, testNetwork)
 					netType := command.StdoutStr(o, "network", "inspect", testNetwork, "--mode=native",
@@ -91,7 +89,6 @@ func NetworkCreate(o *option.Option) {
 		}
 
 		for _, opt := range []string{"-o", "--opt"} {
-			opt := opt
 			ginkgo.It(fmt.Sprintf("should set the containers network MTU with %s flag", opt), func() {
 				command.Run(o, "network", "create", opt, "com.docker.network.driver.mtu=500", testNetwork)
 				mtu := command.StdoutStr(o, "network", "inspect", testNetwork, "--mode=native", "--format", "{{(index .CNI.plugins 0).mtu}}")

--- a/tests/network_ls.go
+++ b/tests/network_ls.go
@@ -34,7 +34,6 @@ func NetworkLs(o *option.Option) {
 		})
 
 		for _, quiet := range []string{"-q", "--quiet"} {
-			quiet := quiet
 			ginkgo.It(fmt.Sprintf("should only display network id with %s flag", quiet), func() {
 				output := command.StdoutStr(o, "network", "ls", quiet)
 				gomega.Expect(output).ShouldNot(gomega.BeEmpty())

--- a/tests/ps.go
+++ b/tests/ps.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+
 	"github.com/runfinch/common-tests/command"
 	"github.com/runfinch/common-tests/option"
 )
@@ -41,7 +42,6 @@ func Ps(o *option.Option) {
 		})
 
 		for _, flag := range []string{"-a", "--all"} {
-			flag := flag
 			ginkgo.It(fmt.Sprintf("should list all containers [%s flag]", flag), func() {
 				psOutput := command.StdoutAsLines(o, "ps", "--format", "{{.Names}}", flag)
 				gomega.Expect(psOutput).Should(gomega.ContainElements(containerNames))
@@ -70,7 +70,6 @@ func Ps(o *option.Option) {
 		})
 
 		for _, flag := range []string{"-q", "--quiet"} {
-			flag := flag
 			ginkgo.It(fmt.Sprintf("should list truncated container IDs [%s flag]", flag), func() {
 				psOutput := command.StdoutAsLines(o, "ps", flag)
 				gomega.Expect(psOutput).ShouldNot(gomega.BeEmpty())
@@ -85,7 +84,6 @@ func Ps(o *option.Option) {
 		})
 
 		for _, flag := range []string{"-s", "--size"} {
-			flag := flag
 			ginkgo.It(fmt.Sprintf("should list container size [%s flag]", flag), func() {
 				psOutput := command.StdoutStr(o, "ps", "--format", "{{.Size}}", flag)
 				gomega.Expect(psOutput).ShouldNot(gomega.BeEmpty())
@@ -93,7 +91,6 @@ func Ps(o *option.Option) {
 		}
 
 		for _, flag := range []string{"-n", "--last"} {
-			flag := flag
 			ginkgo.It(fmt.Sprintf("should list last 1 containers [%s flag]", flag), func() {
 				psOutput := command.StdoutAsLines(o, "ps", "--format", "{{.Names}}", flag, "1")
 				gomega.Expect(psOutput).ShouldNot(gomega.ContainElement(containerNames[0]))
@@ -102,7 +99,6 @@ func Ps(o *option.Option) {
 		}
 
 		for _, flag := range []string{"-l", "--latest"} {
-			flag := flag
 			ginkgo.It(fmt.Sprintf("should list last 1 containers [%s flag]", flag), func() {
 				psOutput := command.StdoutAsLines(o, "ps", "--format", "{{.Names}}", flag)
 				gomega.Expect(psOutput).ShouldNot(gomega.ContainElement(containerNames[0]))
@@ -208,7 +204,6 @@ func Ps(o *option.Option) {
 		}
 
 		for _, test := range filterTests {
-			test := test
 			ginkgo.It(fmt.Sprintf(" should list container with filter %s", test.filter), func() {
 				output := command.StdoutAsLines(o, "ps", "-a", "--format", "{{.Names}}", "--filter", test.filter)
 				gomega.Expect(output).Should(gomega.ContainElements(test.expectedOutput))

--- a/tests/rm.go
+++ b/tests/rm.go
@@ -43,7 +43,6 @@ func Rm(o *option.Option) {
 			})
 
 			for _, force := range []string{"-f", "--force"} {
-				force := force
 				ginkgo.It(fmt.Sprintf("should be able to remove the container with %s flag", force), func() {
 					command.Run(o, "rm", force, testContainerName)
 					err := containerShouldNotExist(o, testContainerName)
@@ -54,7 +53,6 @@ func Rm(o *option.Option) {
 
 		ginkgo.Context("when a volume is used by the container", func() {
 			for _, volumes := range []string{"-v", "--volumes"} {
-				volumes := volumes
 				ginkgo.It(fmt.Sprintf("with %s flag, should remove the container and the anonymous volume used by the container", volumes),
 					func() {
 						command.Run(o, "run", "-v", "/usr/share", "--name", testContainerName, localImages[defaultImage])

--- a/tests/rmi.go
+++ b/tests/rmi.go
@@ -41,7 +41,6 @@ func Rmi(o *option.Option) {
 			})
 
 			for _, force := range []string{"-f", "--force"} {
-				force := force
 				ginkgo.It(fmt.Sprintf("should be able to remove the image with %s flag", force), func() {
 					command.Run(o, "rmi", force, localImages[defaultImage])
 					imageShouldNotExist(o, localImages[defaultImage])

--- a/tests/run.go
+++ b/tests/run.go
@@ -83,7 +83,6 @@ func Run(o *RunOption) {
 
 		ginkgo.When("running a container with metadata related flags", func() {
 			for _, label := range []string{"-l", "--label"} {
-				label := label
 				ginkgo.It(fmt.Sprintf("should set meta data on a container with %s flag", label), func() {
 					command.Run(o.BaseOpt, "run", "--name", testContainerName, label, "testKey=testValue", localImages[defaultImage])
 					gomega.Expect(command.StdoutStr(o.BaseOpt, "inspect", testContainerName,
@@ -129,7 +128,6 @@ func Run(o *RunOption) {
 			})
 
 			for _, workDir := range []string{"--workdir", "-w"} {
-				workDir := workDir
 				ginkgo.It(fmt.Sprintf("should set working directory inside the container specified by %s flag", workDir), func() {
 					dir := "/tmp"
 					gomega.Expect(
@@ -146,7 +144,6 @@ func Run(o *RunOption) {
 			}
 
 			for _, env := range []string{"-e", "--env"} {
-				env := env
 				ginkgo.It(fmt.Sprintf("with %s flag, environment variables should be set in the container", env), func() {
 					envOutput := command.Stdout(o.BaseOpt, "run", "--rm",
 						env, "FOO=BAR", env, "FOO1", env, "ENV1=1", env, "ENV1=2",
@@ -234,7 +231,6 @@ func Run(o *RunOption) {
 		})
 
 		for _, interactive := range []string{"-i", "--interactive"} {
-			interactive := interactive
 			ginkgo.It(fmt.Sprintf("should output string if %s flag keeps STDIN open", interactive), func() {
 				want := []byte("hello")
 				got := command.New(o.BaseOpt, "run", interactive, localImages[defaultImage], "cat").
@@ -305,7 +301,6 @@ func Run(o *RunOption) {
 		ginkgo.When("running a container with network related flags", func() {
 			// TODO: add tests for --ip, --mac-address flags
 			for _, network := range []string{"--net", "--network"} {
-				network := network
 				ginkgo.It(fmt.Sprintf("should connect a container to a network with %s flag", network), func() {
 					command.Run(o.BaseOpt, "run", "-d", network, "bridge", "--name", testContainerName,
 						localImages[defaultImage], "sh", "-c", "echo hello | nc -l -p 80")
@@ -358,7 +353,6 @@ func Run(o *RunOption) {
 			})
 
 			for _, dnsOption := range []string{"--dns-opt", "--dns-option"} {
-				dnsOption := dnsOption
 				ginkgo.It(fmt.Sprintf("should be able to set DNS option with %s flag", dnsOption), func() {
 					lines := command.StdoutAsLines(o.BaseOpt, "run", dnsOption, "debug", "--name", testContainerName,
 						localImages[defaultImage], "cat", "/etc/resolv.conf")
@@ -367,7 +361,6 @@ func Run(o *RunOption) {
 			}
 
 			for _, hostname := range []string{"--hostname", "-h"} {
-				hostname := hostname
 				ginkgo.It(fmt.Sprintf("should be able to set container host name with %s flag", hostname), func() {
 					name := command.StdoutStr(o.BaseOpt, "run", hostname, "foo", localImages[defaultImage], "hostname")
 					gomega.Expect(name).Should(gomega.Equal("foo"))
@@ -417,7 +410,6 @@ func Run(o *RunOption) {
 			})
 
 			for _, publish := range []string{"-p", "--publish"} {
-				publish := publish
 				ginkgo.It(fmt.Sprintf("port of the container should be published to the host port with %s flag", publish), func() {
 					const containerPort = 80
 					hostPort := fnet.GetFreePort()
@@ -440,7 +432,6 @@ func Run(o *RunOption) {
 				tmpfsType  = "tmpfs"
 			)
 			for _, volume := range []string{"-v", "--volume"} {
-				volume := volume
 				ginkgo.It(fmt.Sprintf("should mount a volume when running a container with %s", volume), func() {
 					command.Run(o.BaseOpt, "run", "--name", testContainerName, volume,
 						fmt.Sprintf("%s:%s", testVolumeName, destDir), localImages[defaultImage], "sh", "-c", "echo foo > /tmp/test.txt")
@@ -700,7 +691,6 @@ func Run(o *RunOption) {
 		})
 
 		for _, user := range []string{"-u", "--user"} {
-			user := user
 			ginkgo.It(fmt.Sprintf("should set the user of a container with %s flag", user), func() {
 				// Ref: https://wiki.gentoo.org/wiki/UID_GID_Assignment_Table
 				testCases := map[string][]string{

--- a/tests/save.go
+++ b/tests/save.go
@@ -58,7 +58,6 @@ func Save(o *option.Option) {
 			})
 
 			for _, outputOption := range []string{"-o", "--output"} {
-				outputOption := outputOption
 				ginkgo.It(fmt.Sprintf("should save an image with %s option", outputOption), func() {
 					command.Run(o, "save", localImages[defaultImage], outputOption, tarFilePath)
 

--- a/tests/start.go
+++ b/tests/start.go
@@ -36,7 +36,6 @@ func Start(o *option.Option) {
 		})
 
 		for _, attach := range []string{"--attach", "-a", "-a=true", "--attach=true"} {
-			attach := attach
 			ginkgo.It(fmt.Sprintf("with %s flag, should start the container with stdout", attach), func() {
 				command.Run(o, "create", "--name", testContainerName, localImages[defaultImage], "echo", "foo")
 				output := command.StdoutStr(o, "start", attach, testContainerName)

--- a/tests/stop.go
+++ b/tests/stop.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+
 	"github.com/runfinch/common-tests/command"
 	"github.com/runfinch/common-tests/option"
 )
@@ -32,7 +33,6 @@ func Stop(o *option.Option) {
 		})
 
 		for _, timeFlag := range []string{"-t", "--time"} {
-			timeFlag := timeFlag
 			ginkgo.It(fmt.Sprintf("should stop running container within specified time by %s flag", timeFlag), func() {
 				// With PID=1, `sleep infinity` does not exit due to receiving a SIGTERM, which is sent by the stop command.
 				// Ref. https://superuser.com/a/1299463/730265

--- a/tests/volume_ls.go
+++ b/tests/volume_ls.go
@@ -32,7 +32,6 @@ func VolumeLs(o *option.Option) {
 		})
 
 		for _, quiet := range []string{"--quiet", "-q"} {
-			quiet := quiet
 			ginkgo.It(fmt.Sprintf("should only display volume names with %s flag", quiet), func() {
 				command.Run(o, "volume", "create", testVolumeName)
 				gomega.Expect(command.StdoutAsLines(o, "volume", "ls", quiet)).Should(gomega.ContainElement(testVolumeName))

--- a/tests/volume_prune.go
+++ b/tests/volume_prune.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega/gbytes"
+
 	"github.com/runfinch/common-tests/command"
 	"github.com/runfinch/common-tests/option"
 )
@@ -41,7 +42,6 @@ func VolumePrune(o *option.Option) {
 		})
 
 		for _, force := range []string{"--force", "-f"} {
-			force := force
 			ginkgo.It(fmt.Sprintf("should remove all unused volumes without prompting for confirmation with %s flag", force), func() {
 				command.Run(o, "volume", "create", testVolumeName)
 				command.Run(o, "volume", "prune", force, "--all")


### PR DESCRIPTION
Issue #, if available:
https://github.com/runfinch/common-tests/pull/190 updates ginkgo third-party dependency which comes with Go 1.22 minimum requirements and requires golangci-lint update.

*Description of changes:*
This change updates the golangci-lint version to v1.62.2 and resolves all warnings and errors. This is required to unblock https://github.com/runfinch/common-tests/pull/190

*Testing done:
Lint is successful in CI

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.