### PR TITLE
feat: specify builder prune -f for no prompt

### DIFF
--- a/tests/builder_prune.go
+++ b/tests/builder_prune.go
@@ -32,7 +32,7 @@ func BuilderPrune(o *option.Option) {
 			command.Run(o, "build", "--output=type=docker", buildContext)
 			// There is no interface to validate the current builder cache size.
 			// To validate in Buildkit, run `buildctl du -v`.
-			command.Run(o, "builder", "prune")
+			command.Run(o, "builder", "prune", "-f")
 		})
 	})
 }


### PR DESCRIPTION
Issue #, if available:
#196

*Description of changes:*
This change adds -f flag to builder prune for no prompt confirmation.

*Testing done:*
Ran test in https://github.com/runfinch/finch-core/pull/472

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.