### PR TITLE
feat: create volume command should be idempotent

### DIFF
--- a/tests/volume_create.go
+++ b/tests/volume_create.go
@@ -64,9 +64,11 @@ func VolumeCreate(o *option.Option) {
 			gomega.Expect(tag1).Should(gomega.Equal("tag1"))
 		})
 
-		ginkgo.It("should not create a volume if the volume with the same name exists", func() {
+		ginkgo.It("should warn volume already exists if a volume with the same name exists", func() {
 			command.Run(o, "volume", "create", testVolumeName)
-			command.RunWithoutSuccessfulExit(o, "volume", "create", testVolumeName)
+			session := command.Run(o, "volume", "create", testVolumeName)
+			gomega.Expect(string(session.Err.Contents())).Should(gomega.ContainSubstring("already exists"))
+			gomega.Expect(string(session.Out.Contents())).Should(gomega.ContainSubstring(testVolumeName))
 		})
 	})
 }


### PR DESCRIPTION
Issue #, if available:
#198 

*Description of changes:*
This change tests that volume creation is idempotent. Before the behavior was to fail with exit code 1; however, starting with nerdctl 2.0 the expected behavior is to warn users and continue with no error.

*Testing done:*
Ran test in https://github.com/runfinch/finch-core/pull/472

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.