### PR TITLE
feat: specify no-trunc for full snapshot ID

### DIFF
--- a/tests/image_history.go
+++ b/tests/image_history.go
@@ -36,13 +36,15 @@ func ImageHistory(o *option.Option) {
 		for _, quiet := range []string{"-q", "--quiet"} {
 			quiet := quiet
 			ginkgo.It(fmt.Sprintf("should only display snapshot ID with %s flag", quiet), func() {
-				ids := removeMissingID(command.StdoutAsLines(o, "image", "history", quiet, localImages[defaultImage]))
+				output := command.StdoutAsLines(o, "image", "history", quiet, "--no-trunc", localImages[defaultImage])
+				ids := removeMissingID(output)
 				gomega.Expect(ids).Should(gomega.HaveEach(gomega.MatchRegexp(sha256RegexFull)))
 			})
 		}
 
 		ginkgo.It("should only display snapshot ID with --format flag", func() {
-			ids := removeMissingID(command.StdoutAsLines(o, "image", "history", localImages[defaultImage], "--format", "{{.Snapshot}}"))
+			output := command.StdoutAsLines(o, "image", "history", "--no-trunc", localImages[defaultImage], "--format", "{{.Snapshot}}")
+			ids := removeMissingID(output)
 			gomega.Expect(ids).Should(gomega.HaveEach(gomega.MatchRegexp(sha256RegexFull)))
 		})
 


### PR DESCRIPTION
Issue #, if available:
#200 

*Description of changes:*
This change adds --no-trunc option for image history tests which expect the full sha256 snapshot ID. Starting in nerdctl 2.0, image history command not specified with no truncation option will display a shorter snapshot ID. This test should continue to work against older Finch versions which have support for --no-trunc option.

```
austin@nimbus:~/workspace/nerdctl$ nerdctl image history --format "{{.Snapshot}}" alpine:3.19
<missing>
sha256:ba79b2c0127890636a791eb3ec3993cce08a5…
```

*Testing done:*
Ran test in https://github.com/runfinch/finch-core/pull/472

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.