### PR TITLE
fix: use compose stop/rm for forceful termination of stubborn containers

### DIFF
--- a/tests/compose_kill.go
+++ b/tests/compose_kill.go
@@ -33,7 +33,8 @@ func ComposeKill(o *option.Option) {
 		})
 
 		ginkgo.AfterEach(func() {
-			command.Run(o, "compose", "down", "--file", composeFilePath)
+			command.Run(o, "compose", "stop", "--timeout", "1", "--file", composeFilePath)
+			command.Run(o, "compose", "rm", "--force", "--file", composeFilePath)
 			command.RemoveAll(o)
 		})
 		ginkgo.It("should kill all service", func() {

--- a/tests/compose_logs.go
+++ b/tests/compose_logs.go
@@ -35,7 +35,8 @@ func ComposeLogs(o *option.Option) {
 		})
 
 		ginkgo.AfterEach(func() {
-			command.Run(o, "compose", "down", "--file", composeFilePath)
+			command.Run(o, "compose", "stop", "--timeout", "1", "--file", composeFilePath)
+			command.Run(o, "compose", "rm", "--force", "--file", composeFilePath)
 			command.RemoveAll(o)
 		})
 		ginkgo.It("should show the logs with prefixes", func() {


### PR DESCRIPTION
Issue #, if available:
#202

*Description of changes:*
This change refactors compose logs and compose kill test suites to use
compose stop/rm for cleanup. Starting in nerdctl 2.0, compose down
attempts to gracefully teardown containers before sending forceful kill
signal after a 10 second timeout. For developer experience, this is
acceptable, but in automation it does not work well. Compose stop/rm is
more preferable for stubborn containers like sleep infinity.

*Testing done:*
Ran test in https://github.com/runfinch/finch-core/pull/472

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.