### PR TITLE
feat: add option features to skip tests

### DIFF
--- a/option/modifier.go
+++ b/option/modifier.go
@@ -30,3 +30,12 @@ func Env(env []string) Modifier {
 		o.env = env
 	})
 }
+
+// WithNoEnvironmentVariablePassthrough denotes the option does not support environment variable passthrough.
+//
+// This is useful for disabling tests that require this feature.
+func WithNoEnvironmentVariablePassthrough() Modifier {
+	return newFuncModifier(func(o *Option) {
+		delete(o.features, environmentVariablePassthrough)
+	})
+}

--- a/tests/compose_build.go
+++ b/tests/compose_build.go
@@ -45,6 +45,10 @@ func ComposeBuild(o *option.Option) {
 		})
 
 		ginkgo.It("should build services defined in the compose file specified by the COMPOSE_FILE environment variable", func() {
+			if !o.SupportsEnvVarPassthrough() {
+				ginkgo.Skip("Test requires option environment variable passthrough")
+			}
+
 			envKey := "COMPOSE_FILE"
 			o.UpdateEnv(envKey, composeFilePath)
 


### PR DESCRIPTION
Issue #, if available:
Resolves https://github.com/runfinch/common-tests/issues/209

finch-core currently uses limactl shell + nerdctl to test macOS VM image and container runtime archive updates. Currently there is no simple solution for passing through environment variables which is required for compose build test suite. This is currently blocking common-tests updates in finch-core.

*Description of changes:*
This change adds features map to option for skipping unsupported tests based on supported features.

*Testing done:*

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.