### PR TITLE
fix: make tests backwards compatible with nerdctl v1

### DIFF
--- a/option/modifier.go
+++ b/option/modifier.go
@@ -39,3 +39,13 @@ func WithNoEnvironmentVariablePassthrough() Modifier {
 		delete(o.features, environmentVariablePassthrough)
 	})
 }
+
+// WithNerdctlVersion denotes the underlying nerdctl version.
+//
+// This is useful for tests whose expectations change based on
+// the underlying nerdctl version.
+func WithNerdctlVersion(version string) Modifier {
+	return newFuncModifier(func(o *Option) {
+		o.features[nerdctlVersion] = version
+	})
+}

--- a/option/nerdctl.go
+++ b/option/nerdctl.go
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package option
+
+import "regexp"
+
+const (
+	nerdctl1xx            = "1.x.x"
+	nerdctl2xx            = "2.x.x"
+	defaultNerdctlVersion = nerdctl2xx
+)
+
+var (
+	nerdctl1xxRegex = regexp.MustCompile(`^1\.[x0-9]+\.[x0-9]+`)
+	nerdctl2xxRegex = regexp.MustCompile(`^2\.[x0-9]+\.[x0-9]+`)
+)
+
+func isNerdctl1xx(version string) bool {
+	return nerdctl1xxRegex.MatchString(version)
+}
+
+func isNerdctl2xx(version string) bool {
+	return nerdctl2xxRegex.MatchString(version)
+}

--- a/option/option_test.go
+++ b/option/option_test.go
@@ -1,0 +1,116 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package option
+
+import "testing"
+
+func TestSupportsEnvVarPassthrough(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mods   []Modifier
+		assert func(*testing.T, *Option)
+	}{
+		{
+			name: "IsEnvVarPassthroughByDefault",
+			mods: []Modifier{},
+			assert: func(t *testing.T, uut *Option) {
+				if !uut.SupportsEnvVarPassthrough() {
+					t.Fatal("expected SupportsEnvVarPassthrough to be true")
+				}
+			},
+		},
+		{
+			name: "IsNotEnvVarPassthrough",
+			mods: []Modifier{
+				WithNoEnvironmentVariablePassthrough(),
+			},
+			assert: func(t *testing.T, uut *Option) {
+				if uut.SupportsEnvVarPassthrough() {
+					t.Fatal("expected SupportsEnvVarPassthrough to be false")
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			uut, err := New([]string{"nerdctl"}, test.mods...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			test.assert(t, uut)
+		})
+	}
+}
+
+func TestNerdctlVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mods   []Modifier
+		assert func(*testing.T, *Option)
+	}{
+		{
+			name: "IsNerdctlV2ByDefault",
+			mods: []Modifier{},
+			assert: func(t *testing.T, uut *Option) {
+				if !uut.IsNerdctlV2() {
+					t.Fatal("expected IsNerdctlV2 to be true")
+				}
+			},
+		},
+		{
+			name: "IsNerdctlV1",
+			mods: []Modifier{
+				WithNerdctlVersion("1.7.7"),
+			},
+			assert: func(t *testing.T, uut *Option) {
+				if !uut.IsNerdctlV1() {
+					t.Fatal("expected IsNerdctlV1 to be true")
+				}
+			},
+		},
+		{
+			name: "IsNerdctlV2",
+			mods: []Modifier{
+				WithNerdctlVersion("2.0.2"),
+			},
+			assert: func(t *testing.T, uut *Option) {
+				if !uut.IsNerdctlV2() {
+					t.Fatal("expected IsNerdctlV2 to be true")
+				}
+			},
+		},
+		{
+			name: "IsPatchedNerdctlV2",
+			mods: []Modifier{
+				WithNerdctlVersion("2.0.2.m"),
+			},
+			assert: func(t *testing.T, uut *Option) {
+				if !uut.IsNerdctlV2() {
+					t.Fatal("expected IsNerdctlV2 to be true")
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			uut, err := New([]string{"nerdctl"}, test.mods...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			test.assert(t, uut)
+		})
+	}
+}

--- a/tests/builder_prune.go
+++ b/tests/builder_prune.go
@@ -32,7 +32,15 @@ func BuilderPrune(o *option.Option) {
 			command.Run(o, "build", "--output=type=docker", buildContext)
 			// There is no interface to validate the current builder cache size.
 			// To validate in Buildkit, run `buildctl du -v`.
-			command.Run(o, "builder", "prune", "-f")
+			args := []string{"builder", "prune"}
+
+			// TODO(macedonv): remove after nerdctlv2 is supported across all platforms.
+			if o.IsNerdctlV2() {
+				// Do not prompt for user response during automated testing.
+				args = append(args, "--force")
+			}
+
+			command.Run(o, args...)
 		})
 	})
 }

--- a/tests/volume_create.go
+++ b/tests/volume_create.go
@@ -64,7 +64,20 @@ func VolumeCreate(o *option.Option) {
 			gomega.Expect(tag1).Should(gomega.Equal("tag1"))
 		})
 
+		ginkgo.It("should not create a volume if the volume with the same name exists", func() {
+			// TODO(macedonv): remove entire test after nerdctl v2 is supported on all platforms.
+			if o.IsNerdctlV2() {
+				ginkgo.Skip("Behavior is not supported on nerdctl v2")
+			}
+			command.Run(o, "volume", "create", testVolumeName)
+			command.RunWithoutSuccessfulExit(o, "volume", "create", testVolumeName)
+		})
+
 		ginkgo.It("should warn volume already exists if a volume with the same name exists", func() {
+			// TODO(macedonv): remove check when nerdctl v2 is supported on all platforms.
+			if o.IsNerdctlV1() {
+				ginkgo.Skip("Behavior is not supported on nerdctl v1")
+			}
 			command.Run(o, "volume", "create", testVolumeName)
 			session := command.Run(o, "volume", "create", testVolumeName)
 			gomega.Expect(string(session.Err.Contents())).Should(gomega.ContainSubstring("already exists"))


### PR DESCRIPTION
Issue #, if available:
nerdctl v2 rollout is quick for macOS and Windows, but slow for Linux (~weeks).

*Description of changes:*
This change enables test runners to specify the nerdctl version depending on the runtime for that platform and tests will run accordingly.

*Testing done:*
Ran in https://github.com/runfinch/finch/pull/1237

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.