### PR TITLE
fix: buildkit cache prune

### DIFF
--- a/tests/tests.go
+++ b/tests/tests.go
@@ -234,3 +234,21 @@ func buildImage(o *option.Option, imageName string) {
 	ginkgo.DeferCleanup(os.RemoveAll, buildContext)
 	command.Run(o, "build", "-q", "-t", imageName, buildContext)
 }
+
+func buildCacheShouldExist() {
+	buildctlOpts, err := option.New([]string{"buildctl"})
+	if err != nil {
+		ginkgo.Fail(err.Error())
+	}
+	cmdOut := command.Run(buildctlOpts, "du", "--format", "json")
+	gomega.Expect(strings.TrimSpace(string(cmdOut.Out.Contents()))).ToNot(gomega.Equal("null"))
+}
+
+func buildCacheShouldNotExist() {
+	buildctlOpts, err := option.New([]string{"buildctl"})
+	if err != nil {
+		ginkgo.Fail(err.Error())
+	}
+	cmdOut := command.Run(buildctlOpts, "du", "--format", "json")
+	gomega.Expect(strings.TrimSpace(string(cmdOut.Out.Contents()))).To(gomega.Equal("null"))
+}


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
Fix test to check buildkit cache is cleared on prune

*Testing done:*
Tested locally to confirm builder prune is able to remove dangling build cache.


- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.