### PR TITLE
fix: improve container cleanup in e2e aftereach step

### DIFF
--- a/command/remove.go
+++ b/command/remove.go
@@ -31,8 +31,13 @@ func RemoveContainers(o *option.Option) {
 		return
 	}
 
+	// Stop all containers first to ensure they can be removed
+	stopArgs := append([]string{"stop", "--time", "1"}, ids...)
+	New(o, stopArgs...).WithoutCheckingExitCode().Run()
+
+	// Remove containers, ignoring failures to prevent test cleanup from failing
 	args := append([]string{"rm", "--force"}, ids...)
-	Run(o, args...)
+	New(o, args...).WithoutCheckingExitCode().Run()
 }
 
 // RemoveVolumes removes all unused local volumes in the testing environment specified by o.


### PR DESCRIPTION
*Description of changes:* The [Build, test and upload .deb to S3](https://github.com/runfinch/finch/actions/workflows/build-and-test-deb.yaml) workflow in Finch has been consistently. The issue occurs when RemoveContainers() attempts to remove containers after tests complete. I believe the cleanup code was too strict - it expected all container removal operations to succeed. When rm --force failed or timed out (due to containers not being fully stopped, resource contention, or timing issues), the entire test would fail even though the actual test logic passed.

*Testing done:* I ran the focused test command below in common-tests and got all passing:
```
go test -timeout 30m ./run/... -test.v -ginkgo.v -ginkgo.focus="user" -args --subject="finch" 2>&1 | tee user-test.log
```
However, I need to do more testing to confirm this fix.

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.