### PR TITLE
feat(windows): support windows by converting windows paths to wsl paths

### DIFF
--- a/option/modifier.go
+++ b/option/modifier.go
@@ -49,3 +49,16 @@ func WithNerdctlVersion(version string) Modifier {
 		o.features[nerdctlVersion] = version
 	})
 }
+
+// WithWindowsHostPathTranslation makes the option rewrite Windows drive-letter
+// paths (e.g. `C:\Users\foo`) in command arguments to their WSL2 equivalents
+// (e.g. `/mnt/c/Users/foo`) before executing.
+//
+// This is done in the Finch CLI too.
+// See (https://github.com/runfinch/finch/blob/ff1346b1d76f083ba86433e4501cbb5e5ce29634/cmd/finch/nerdctl_windows.go#L72),
+// But since common-tests is meant to be executed outside of Finch CLI (e.g Finch Core), we need this as an option.
+func WithWindowsHostPathTranslation() Modifier {
+	return newFuncModifier(func(o *Option) {
+		o.features[windowsHostPathTranslation] = true
+	})
+}

--- a/option/option.go
+++ b/option/option.go
@@ -19,6 +19,7 @@ type feature int
 const (
 	environmentVariablePassthrough feature = iota
 	nerdctlVersion                 feature = iota
+	windowsHostPathTranslation     feature = iota
 )
 
 var (
@@ -56,6 +57,7 @@ func New(subject []string, modifiers ...Modifier) (*Option, error) {
 		features: map[feature]any{
 			environmentVariablePassthrough: true,
 			nerdctlVersion:                 nerdctl2xx,
+			windowsHostPathTranslation:     false,
 		},
 	}
 	for _, modifier := range modifiers {
@@ -68,6 +70,10 @@ func New(subject []string, modifiers ...Modifier) (*Option, error) {
 // NewCmd creates a command using the stored option and the provided args.
 func (o *Option) NewCmd(args ...string) *exec.Cmd {
 	cmdName := o.subject[0]
+	if o.SupportsWindowsHostPathTranslation() {
+		args = translateWindowsHostPaths(args)
+	}
+
 	cmdArgs := append(o.subject[1:], args...) //nolint:gocritic // appendAssign does not apply to our case.
 	cmd := exec.Command(cmdName, cmdArgs...)  //nolint:gosec // G204 is not an issue because cmdName is fully controlled by the user.
 	cmd.Env = append(os.Environ(), o.env...)
@@ -106,6 +112,17 @@ func containsEnv(envs []string, targetEnvKey string) (int, bool) {
 // supports [feature.environmentVariablePassthrough].
 func (o *Option) SupportsEnvVarPassthrough() bool {
 	if value, exists := o.features[environmentVariablePassthrough]; exists {
+		if boolValue, ok := value.(bool); ok {
+			return boolValue
+		}
+	}
+	return false
+}
+
+// SupportsWindowsHostPathTranslation reports whether command arguments should
+// have Windows host paths rewritten to their WSL2 equivalents before execution.
+func (o *Option) SupportsWindowsHostPathTranslation() bool {
+	if value, exists := o.features[windowsHostPathTranslation]; exists {
 		if boolValue, ok := value.(bool); ok {
 			return boolValue
 		}
@@ -159,9 +176,21 @@ func (o *Option) GetNerdctlVersion() (string, error) {
 		//nolint:gosec // G204 is not an issue because subject is fully controlled by the user.
 		versionBytes, err := exec.Command(o.subject[0], "version").Output()
 		if err != nil {
-			return "", fmt.Errorf("failed to run nerdctl --version: %w", err)
+			return "", fmt.Errorf("failed to run finch version: %w", err)
 		}
 		version, err := getNerdctlVersionMatch(finchNerdctlVersionRegex, string(versionBytes))
+		if err != nil {
+			return "", err
+		}
+		return version, nil
+	case "limactl":
+		// Assumes that "finch" is the vm name
+		//nolint:gosec // G204 is not an issue because subject is fully controlled by the user.
+		versionBytes, err := exec.Command(o.subject[0], "shell", "finch", "nerdctl", "--version").Output()
+		if err != nil {
+			return "", fmt.Errorf("failed to run nerdctl --version with limactl: %w", err)
+		}
+		version, err := getNerdctlVersionMatch(nerdctlVersionRegex, string(versionBytes))
 		if err != nil {
 			return "", err
 		}

--- a/option/option_test.go
+++ b/option/option_test.go
@@ -3,7 +3,9 @@
 
 package option
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestSupportsEnvVarPassthrough(t *testing.T) {
 	t.Parallel()
@@ -18,7 +20,7 @@ func TestSupportsEnvVarPassthrough(t *testing.T) {
 			mods: []Modifier{},
 			assert: func(t *testing.T, uut *Option) {
 				if !uut.SupportsEnvVarPassthrough() {
-					t.Fatal("expected SupportsEnvVarPassthrough to be true")
+					t.Fatal("expected default SupportsEnvVarPassthrough to be true")
 				}
 			},
 		},
@@ -45,6 +47,240 @@ func TestSupportsEnvVarPassthrough(t *testing.T) {
 			}
 
 			test.assert(t, uut)
+		})
+	}
+}
+
+func TestSupportsWindowsHostPathTranslation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mods   []Modifier
+		assert func(*testing.T, *Option)
+	}{
+		{
+			name: "IsNotWindowsHostPathTranslation",
+			mods: []Modifier{},
+			assert: func(t *testing.T, uut *Option) {
+				if uut.SupportsWindowsHostPathTranslation() {
+					t.Fatal("expected default SupportsWindowsHostPathTranslation to be false")
+				}
+			},
+		},
+		{
+			name: "IsWindowsHostPathTranslation",
+			mods: []Modifier{
+				WithWindowsHostPathTranslation(),
+			},
+			assert: func(t *testing.T, uut *Option) {
+				if !uut.SupportsWindowsHostPathTranslation() {
+					t.Fatal("expected SupportsWindowsHostPathTranslation to be true")
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			uut, err := New([]string{"nerdctl"}, test.mods...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			test.assert(t, uut)
+		})
+	}
+}
+
+func TestTranslateWindowsHostPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "BuildContextPositional",
+			in:   []string{"build", "-t", "foo", `C:\Users\foo\finch-test123`},
+			want: []string{"build", "-t", "foo", "/mnt/c/Users/foo/finch-test123"},
+		},
+		{
+			name: "BuildDockerfileAndContext",
+			in:   []string{"build", "-f", `D:\a\Dockerfile`, "--no-cache", `D:\a`},
+			want: []string{"build", "-f", "/mnt/d/a/Dockerfile", "--no-cache", "/mnt/d/a"},
+		},
+		{
+			name: "BuildOutputDest",
+			in:   []string{"build", "-t", "output:tag", "--output", `type=tar,dest=C:\Users\foo\out.tar`, `C:\ctx`},
+			want: []string{"build", "-t", "output:tag", "--output", "type=tar,dest=/mnt/c/Users/foo/out.tar", "/mnt/c/ctx"},
+		},
+		{
+			name: "BuildOutputEqualsForm",
+			in:   []string{"build", `--output=type=docker`, `C:\ctx`},
+			want: []string{"build", "--output=type=docker", "/mnt/c/ctx"},
+		},
+		{
+			name: "BuildSecretSrc",
+			in:   []string{"build", "--secret", `id=mysecret,src=C:\Users\foo\secret.txt`, "-f", `C:\Users\foo\Dockerfile`, `C:\Users\foo`},
+			want: []string{
+				"build", "--secret", "id=mysecret,src=/mnt/c/Users/foo/secret.txt",
+				"-f", "/mnt/c/Users/foo/Dockerfile", "/mnt/c/Users/foo",
+			},
+		},
+		{
+			name: "SaveOutputFlag",
+			in:   []string{"save", "-o", `C:\Users\foo\test.tar`, "alpine:latest"},
+			want: []string{"save", "-o", "/mnt/c/Users/foo/test.tar", "alpine:latest"},
+		},
+		{
+			name: "SaveOutputFlagBeforeImages",
+			in:   []string{"save", "--output", `C:\Users\foo\test.tar`, "alpine:latest", "alpine:3.13"},
+			want: []string{"save", "--output", "/mnt/c/Users/foo/test.tar", "alpine:latest", "alpine:3.13"},
+		},
+		{
+			name: "LoadInputFlag",
+			in:   []string{"load", "-i", `C:\Users\foo\test.tar`},
+			want: []string{"load", "-i", "/mnt/c/Users/foo/test.tar"},
+		},
+		{
+			name: "ComposeFileFlag",
+			in:   []string{"compose", "up", "--file", `C:\Users\foo\docker-compose.yml`},
+			want: []string{"compose", "up", "--file", "/mnt/c/Users/foo/docker-compose.yml"},
+		},
+		{
+			name: "CpHostToContainer",
+			in:   []string{"cp", `C:\Users\foo\test-file`, "finch-test-ctr:/tmp/test-file"},
+			want: []string{"cp", "/mnt/c/Users/foo/test-file", "finch-test-ctr:/tmp/test-file"},
+		},
+		{
+			name: "CpContainerToHost",
+			in:   []string{"cp", "finch-test-ctr:/tmp/test-file", `C:\Users\foo\test-file`},
+			want: []string{"cp", "finch-test-ctr:/tmp/test-file", "/mnt/c/Users/foo/test-file"},
+		},
+		{
+			name: "CpWithFollowLinkFlagAndContainerSpec",
+			in:   []string{"cp", "-L", `C:\Users\foo\symlink`, "finch-test-ctr:/tmp/test-file"},
+			want: []string{"cp", "-L", "/mnt/c/Users/foo/symlink", "finch-test-ctr:/tmp/test-file"},
+		},
+		{
+			name: "ExecEnvFileFlag",
+			in:   []string{"exec", "--env-file", `C:\Users\foo\env`, "finch-test-ctr", "env"},
+			want: []string{"exec", "--env-file", "/mnt/c/Users/foo/env", "finch-test-ctr", "env"},
+		},
+		{
+			name: "RunEnvFileFlag",
+			in:   []string{"run", "--rm", "--env-file", `C:\Users\foo\env`, "alpine:latest", "env"},
+			want: []string{"run", "--rm", "--env-file", "/mnt/c/Users/foo/env", "alpine:latest", "env"},
+		},
+		{
+			name: "RunCidFileFlag",
+			in:   []string{"run", "-d", "--cidfile", `C:\Users\foo\test.cid`, "alpine:latest"},
+			want: []string{"run", "-d", "--cidfile", "/mnt/c/Users/foo/test.cid", "alpine:latest"},
+		},
+		{
+			name: "RunLabelFileFlag",
+			in:   []string{"run", "--name", "ctr", "--label-file", `C:\Users\foo\label-file`, "alpine:latest"},
+			want: []string{"run", "--name", "ctr", "--label-file", "/mnt/c/Users/foo/label-file", "alpine:latest"},
+		},
+		{
+			name: "RunBindMountHostPathOnly",
+			in:   []string{"run", "-v", `C:\host:/container`, "alpine:3.13"},
+			want: []string{"run", "-v", "/mnt/c/host:/container", "alpine:3.13"},
+		},
+		{
+			name: "RunNamedVolumeUntouched",
+			in:   []string{"run", "-v", "foo:/usr/share", "--name", "ctr", "alpine:3.13"},
+			want: []string{"run", "-v", "foo:/usr/share", "--name", "ctr", "alpine:3.13"},
+		},
+		{
+			name: "RunAnonymousVolumeUntouched",
+			in:   []string{"run", "-v", "/usr/share", "--name", "ctr", "alpine:3.13"},
+			want: []string{"run", "-v", "/usr/share", "--name", "ctr", "alpine:3.13"},
+		},
+		{
+			name: "RunBindMountWindowsPathBothSides",
+			in:   []string{"run", "-v", `C:\host:C:\host`, "alpine:3.13"},
+			want: []string{"run", "-v", "/mnt/c/host:/mnt/c/host", "alpine:3.13"},
+		},
+		{
+			name: "RunWorkdirWindowsPath",
+			in:   []string{"run", "-w", `D:\a\finch`, "alpine:3.13"},
+			want: []string{"run", "-w", "/mnt/d/a/finch", "alpine:3.13"},
+		},
+		{
+			name: "RunWorkdirLongFlagWindowsPath",
+			in:   []string{"run", "--workdir", `C:\Users\foo`, "alpine:3.13"},
+			want: []string{"run", "--workdir", "/mnt/c/Users/foo", "alpine:3.13"},
+		},
+		{
+			name: "RunWorkdirLinuxPathUntouched",
+			in:   []string{"run", "-w", "/app", "alpine:3.13"},
+			want: []string{"run", "-w", "/app", "alpine:3.13"},
+		},
+		{
+			name: "PsVolumeFilterWindowsPath",
+			in:   []string{"ps", "-a", "--format", "{{.Names}}", "--filter", `volume=D:\a\finch`},
+			want: []string{"ps", "-a", "--format", "{{.Names}}", "--filter", "volume=/mnt/d/a/finch"},
+		},
+		{
+			name: "PsVolumeFilterEqualsForm",
+			in:   []string{"ps", `--filter=volume=C:\host`},
+			want: []string{"ps", "--filter=volume=/mnt/c/host"},
+		},
+		{
+			name: "PsNameFilterUntouched",
+			in:   []string{"ps", "--filter", "name=ctr_1"},
+			want: []string{"ps", "--filter", "name=ctr_1"},
+		},
+		{
+			name: "RunMountBindSource",
+			in:   []string{"run", "-d", "--mount", `type=bind,source=C:\Users\foo,target=/app`, "alpine:3.13"},
+			want: []string{"run", "-d", "--mount", "type=bind,source=/mnt/c/Users/foo,target=/app", "alpine:3.13"},
+		},
+		{
+			name: "RunMountBindSrcReadonly",
+			in:   []string{"run", "--mount", `type=bind,src=C:\host,target=/app,ro`, "alpine:3.13"},
+			want: []string{"run", "--mount", "type=bind,src=/mnt/c/host,target=/app,ro", "alpine:3.13"},
+		},
+		{
+			name: "RunMountBindEqualsForm",
+			in:   []string{"run", `--mount=type=bind,source=C:\host,target=/app`, "alpine:3.13"},
+			want: []string{"run", "--mount=type=bind,source=/mnt/c/host,target=/app", "alpine:3.13"},
+		},
+		{
+			name: "RunMountVolumeUntouched",
+			in:   []string{"run", "--mount", "type=volume,source=myvol,target=/app", "alpine:3.13"},
+			want: []string{"run", "--mount", "type=volume,source=myvol,target=/app", "alpine:3.13"},
+		},
+		{
+			name: "RunMountTmpfsUntouched",
+			in:   []string{"run", "--mount", "type=tmpfs,target=/app", "alpine:3.13"},
+			want: []string{"run", "--mount", "type=tmpfs,target=/app", "alpine:3.13"},
+		},
+		{
+			name: "PullImageTagAndFlagsUntouched",
+			in:   []string{"pull", "alpine:3.13", "--platform", "linux/amd64"},
+			want: []string{"pull", "alpine:3.13", "--platform", "linux/amd64"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := translateWindowsHostPaths(test.in)
+			if len(got) != len(test.want) {
+				t.Fatalf("length mismatch: got %v, want %v", got, test.want)
+			}
+			for i := range got {
+				if got[i] != test.want[i] {
+					t.Errorf("arg %d: got %q, want %q", i, got[i], test.want[i])
+				}
+			}
 		})
 	}
 }

--- a/option/wsl_path.go
+++ b/option/wsl_path.go
@@ -1,0 +1,415 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package option
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// The path translation logic here is ported from the Finch CLI:
+// https://github.com/runfinch/finch/blob/ff1346b1d76f083ba86433e4501cbb5e5ce29634/cmd/finch/nerdctl_windows.go
+
+var aliasMap = map[string]string{
+	"build": "image build",
+	"run":   "container run",
+	"cp":    "container cp",
+}
+
+type commandHandler func(args []string) error
+
+type argHandler func(args []string, index int) error
+
+var commandHandlerMap = map[string]commandHandler{
+	"container cp": cpHandler,
+	"image build":  imageBuildHandler,
+}
+
+var argHandlerMap = map[string]map[string]argHandler{
+	"image build": {
+		"-f":        handleFilePath,
+		"--file":    handleFilePath,
+		"-o":        handleOutputOption,
+		"--output":  handleOutputOption,
+		"--secret":  handleSecretOption,
+		"--iidfile": handleFilePath,
+	},
+	"image save": {
+		"-o":       handleFilePath,
+		"--output": handleFilePath,
+	},
+	"image load": {
+		"-i":      handleFilePath,
+		"--input": handleFilePath,
+	},
+	"save": {
+		"-o":       handleFilePath,
+		"--output": handleFilePath,
+	},
+	"load": {
+		"-i":      handleFilePath,
+		"--input": handleFilePath,
+	},
+	"container run": {
+		"-v":           handleVolume,
+		"--volume":     handleVolume,
+		"--mount":      handleMount,
+		"-w":           handleWorkdir,
+		"--workdir":    handleWorkdir,
+		"--env-file":   handleFilePath,
+		"--cidfile":    handleFilePath,
+		"--label-file": handleFilePath,
+	},
+	"run": {
+		"-v":        handleVolume,
+		"--volume":  handleVolume,
+		"--mount":   handleMount,
+		"-w":        handleWorkdir,
+		"--workdir": handleWorkdir,
+	},
+	"create": {
+		"-v":        handleVolume,
+		"--volume":  handleVolume,
+		"--mount":   handleMount,
+		"-w":        handleWorkdir,
+		"--workdir": handleWorkdir,
+	},
+	"ps": {
+		"-f":       handleFilter,
+		"--filter": handleFilter,
+	},
+	"container ps": {
+		"-f":       handleFilter,
+		"--filter": handleFilter,
+	},
+	"exec": {
+		"--env-file": handleFilePath,
+	},
+	"compose": {
+		"-f":     handleFilePath,
+		"--file": handleFilePath,
+	},
+}
+
+func translateWindowsHostPaths(args []string) []string {
+	if len(args) == 0 {
+		return args
+	}
+
+	out := slices.Clone(args)
+
+	cmdName := out[0]
+	rest := out[1:]
+
+	cmdKey := cmdName
+	if alias, ok := aliasMap[cmdName]; ok {
+		cmdKey = alias
+	} else if len(rest) > 0 {
+		if _, ok := commandHandlerMap[cmdName+" "+rest[0]]; ok {
+			cmdKey = cmdName + " " + rest[0]
+		} else if _, ok := argHandlerMap[cmdName+" "+rest[0]]; ok {
+			cmdKey = cmdName + " " + rest[0]
+		}
+	}
+
+	if h, ok := commandHandlerMap[cmdKey]; ok {
+		if err := h(out); err != nil {
+			return out
+		}
+	}
+
+	if aMap, ok := argHandlerMap[cmdKey]; ok {
+		for i := range out {
+			flag, _, _ := strings.Cut(out[i], "=")
+			if h, ok := aMap[flag]; ok {
+				if err := h(out, i); err != nil {
+					return out
+				}
+			}
+		}
+	}
+
+	return out
+}
+
+// convertToWSLPath converts an absolute Windows path (C:\Users\foo) to its WSL2 mount equivalent (/mnt/c/Users/foo).
+func convertToWSLPath(winPath string) string {
+	if len(winPath) < 2 || winPath[1] != ':' {
+		return winPath
+	}
+	drive := strings.ToLower(string(winPath[0]))
+	remaining := ""
+	if len(winPath) > 2 {
+		remaining = winPath[2:]
+	}
+	remaining = strings.ReplaceAll(remaining, `\`, "/")
+	return filepath.ToSlash("/mnt/" + drive + remaining)
+}
+
+func isWindowsPath(s string) bool {
+	return len(s) >= 3 && s[1] == ':' && (s[2] == '\\' || s[2] == '/')
+}
+
+func handleFilePath(args []string, index int) error {
+	arg := args[index]
+	if strings.Contains(arg, "=") {
+		before, after, _ := strings.Cut(arg, "=")
+		args[index] = before + "=" + convertToWSLPath(after)
+		return nil
+	}
+	if index+1 < len(args) {
+		args[index+1] = convertToWSLPath(args[index+1])
+	}
+	return nil
+}
+
+func handleVolume(args []string, index int) error {
+	arg := args[index]
+
+	var (
+		value        string
+		before       string
+		hasEqualForm bool
+	)
+	switch {
+	case strings.Contains(arg, "="):
+		before, value, _ = strings.Cut(arg, "=")
+		hasEqualForm = true
+	case index+1 < len(args):
+		value = args[index+1]
+	default:
+		return nil
+	}
+
+	cleanArg := value
+	readWrite := ""
+	switch {
+	case strings.HasSuffix(value, ":ro"), strings.HasSuffix(value, ":rw"):
+		readWrite = value[len(value)-3:]
+		cleanArg = value[:len(value)-3]
+	case strings.HasSuffix(value, ":rro"):
+		readWrite = value[len(value)-4:]
+		cleanArg = value[:len(value)-4]
+	}
+
+	// The host path must be a Windows drive path (eg C:\...).
+	if !isWindowsPath(cleanArg) {
+		return nil
+	}
+
+	// Split the host and container paths at the separator colon that follows the
+	// host path, skipping the drive-letter colon at index 1 (eg the ':' between
+	// "C:\host" and "/container").
+	sep := strings.IndexByte(cleanArg[2:], ':')
+	if sep < 0 {
+		return nil
+	}
+	sep += 2
+	hostPath := cleanArg[:sep]
+	containerPath := cleanArg[sep+1:]
+
+	wslHostPath := convertToWSLPath(hostPath)
+	// The container path is normally a Linux path, but some tests reuse the host
+	// path (eg `-v <pwd>:<pwd>`); convert it too when it is a Windows path.
+	if isWindowsPath(containerPath) {
+		containerPath = convertToWSLPath(containerPath)
+	}
+
+	if hasEqualForm {
+		args[index] = before + "=" + wslHostPath + ":" + containerPath + readWrite
+	} else {
+		args[index+1] = wslHostPath + ":" + containerPath + readWrite
+	}
+	return nil
+}
+
+func handleMount(args []string, index int) error {
+	arg := args[index]
+
+	var (
+		value        string
+		before       string
+		hasEqualForm bool
+	)
+	switch {
+	case strings.Contains(arg, "="):
+		before, value, _ = strings.Cut(arg, "=")
+		hasEqualForm = true
+	case index+1 < len(args):
+		value = args[index+1]
+	default:
+		return nil
+	}
+
+	entries := strings.Split(value, ",")
+	m := make(map[string]string)
+	for _, e := range entries {
+		k, v, found := strings.Cut(e, "=")
+		if found {
+			m[strings.TrimSpace(k)] = strings.TrimSpace(v)
+		}
+	}
+
+	// Only translate bind mounts; volume/tmpfs sources are not host paths.
+	if m["type"] != "bind" {
+		return nil
+	}
+
+	key := "src"
+	hostPath, ok := m[key]
+	if !ok {
+		key = "source"
+		hostPath, ok = m[key]
+	}
+	if !ok || !strings.Contains(hostPath, `\`) {
+		return nil
+	}
+
+	for i, e := range entries {
+		k, _, found := strings.Cut(e, "=")
+		if found && strings.TrimSpace(k) == key {
+			entries[i] = k + "=" + convertToWSLPath(hostPath)
+		}
+	}
+	newValue := strings.Join(entries, ",")
+
+	if hasEqualForm {
+		args[index] = before + "=" + newValue
+	} else {
+		args[index+1] = newValue
+	}
+	return nil
+}
+
+func handleWorkdir(args []string, index int) error {
+	arg := args[index]
+	if strings.Contains(arg, "=") {
+		before, after, _ := strings.Cut(arg, "=")
+		if isWindowsPath(after) {
+			args[index] = before + "=" + convertToWSLPath(after)
+		}
+		return nil
+	}
+	if index+1 < len(args) && isWindowsPath(args[index+1]) {
+		args[index+1] = convertToWSLPath(args[index+1])
+	}
+	return nil
+}
+
+func handleFilter(args []string, index int) error {
+	arg := args[index]
+
+	var (
+		value        string
+		before       string
+		hasEqualForm bool
+	)
+	switch {
+	case strings.HasPrefix(arg, "--filter="):
+		before, value, _ = strings.Cut(arg, "=")
+		hasEqualForm = true
+	case strings.HasPrefix(arg, "-f="):
+		before, value, _ = strings.Cut(arg, "=")
+		hasEqualForm = true
+	case index+1 < len(args):
+		value = args[index+1]
+	default:
+		return nil
+	}
+
+	key, path, found := strings.Cut(value, "=")
+	if !found || key != "volume" || !isWindowsPath(path) {
+		return nil
+	}
+	newValue := key + "=" + convertToWSLPath(path)
+
+	if hasEqualForm {
+		args[index] = before + "=" + newValue
+	} else {
+		args[index+1] = newValue
+	}
+	return nil
+}
+
+func handleOutputOption(args []string, index int) error {
+	return convertKeyValueOptionPath(args, index, "dest")
+}
+
+func handleSecretOption(args []string, index int) error {
+	return convertKeyValueOptionPath(args, index, "src")
+}
+
+func convertKeyValueOptionPath(args []string, index int, pathKey string) error {
+	arg := args[index]
+
+	var (
+		value        string
+		before       string
+		hasEqualForm bool
+	)
+	switch {
+	case strings.Contains(arg, "="):
+		before, value, _ = strings.Cut(arg, "=")
+		hasEqualForm = true
+	case index+1 < len(args):
+		value = args[index+1]
+	default:
+		return nil
+	}
+
+	entries := strings.Split(value, ",")
+	converted := false
+	for i, e := range entries {
+		k, v, found := strings.Cut(e, "=")
+		if found && strings.TrimSpace(k) == pathKey {
+			entries[i] = k + "=" + convertToWSLPath(v)
+			converted = true
+		}
+	}
+	if !converted {
+		return nil
+	}
+	newValue := strings.Join(entries, ",")
+
+	if hasEqualForm {
+		args[index] = before + "=" + newValue
+	} else {
+		args[index+1] = newValue
+	}
+	return nil
+}
+
+func cpHandler(args []string) error {
+	for i, arg := range args {
+		if strings.HasPrefix(arg, "-") || arg == "cp" || arg == "container" {
+			continue
+		}
+		if colon := strings.Index(arg, ":"); colon > 1 {
+			continue
+		}
+		args[i] = convertToWSLPath(arg)
+	}
+	return nil
+}
+
+func imageBuildHandler(args []string) error {
+	for _, a := range args {
+		if a == "--help" || a == "-h" {
+			return nil
+		}
+	}
+	last := len(args) - 1
+	if last < 0 {
+		return nil
+	}
+	if args[last] != "--debug" {
+		if isWindowsPath(args[last]) {
+			args[last] = convertToWSLPath(args[last])
+		}
+	} else if last-1 >= 0 && isWindowsPath(args[last-1]) {
+		args[last-1] = convertToWSLPath(args[last-1])
+	}
+	return nil
+}

--- a/tests/run.go
+++ b/tests/run.go
@@ -145,6 +145,10 @@ func Run(o *RunOption) {
 
 			for _, env := range []string{"-e", "--env"} {
 				ginkgo.It(fmt.Sprintf("with %s flag, environment variables should be set in the container", env), func() {
+					if !o.BaseOpt.SupportsEnvVarPassthrough() {
+						ginkgo.Skip("Test requires option environment variable passthrough")
+					}
+
 					envOutput := command.Stdout(o.BaseOpt, "run", "--rm",
 						env, "FOO=BAR", env, "FOO1", env, "ENV1=1", env, "ENV1=2",
 						localImages[defaultImage], "env")
@@ -155,6 +159,10 @@ func Run(o *RunOption) {
 			}
 
 			ginkgo.It("with -e flag passing env variables without a value, only host set vars should be set in the container", func() {
+				if !o.BaseOpt.SupportsEnvVarPassthrough() {
+					ginkgo.Skip("Test requires option environment variable passthrough")
+				}
+
 				gomega.Expect(os.Setenv("AVAR1", "avalue")).To(gomega.Succeed())
 				envOutput := command.Stdout(o.BaseOpt, "run", "--rm",
 					"-e", "AVAR1", "-e", "AVAR2", localImages[defaultImage], "env")
@@ -172,6 +180,10 @@ func Run(o *RunOption) {
 			})
 
 			ginkgo.It("using an env var file, env vars without values should only be set in the container if they are set on the host", func() {
+				if !o.BaseOpt.SupportsEnvVarPassthrough() {
+					ginkgo.Skip("Test requires option environment variable passthrough")
+				}
+
 				const envPair = "ENVKEY=ENVVAL\nAVAR1\nAVAR2\n"
 				envPath := ffs.CreateTempFile("env", envPair)
 				ginkgo.DeferCleanup(os.RemoveAll, filepath.Dir(envPath))
@@ -183,6 +195,10 @@ func Run(o *RunOption) {
 			})
 
 			ginkgo.It("using a file with the --env-file flag, comments and whitespace should be ignored properly", func() {
+				if !o.BaseOpt.SupportsEnvVarPassthrough() {
+					ginkgo.Skip("Test requires option environment variable passthrough")
+				}
+
 				const envPair = "ENVKEY=ENVVAL   \n# this is a comment\n\n AVAR1\nAVAR1\nAVAR2\n  # comment 2\n"
 				envPath := ffs.CreateTempFile("env", envPair)
 				ginkgo.DeferCleanup(os.RemoveAll, filepath.Dir(envPath))


### PR DESCRIPTION
Issue #, if available:

*Description of changes:*
- Adds a `WithWindowsHostPathTranslation` modifier.
- When this modifier is set, rewrite Windows drive-letter paths (e.g. `C:\Users\foo`) in command arguments to their WSL2 equivalents (e.g. `/mnt/c/Users/foo`) before executing nerdctl commands.

#### Note: 
- This path translation is handled by Finch CLI. See - https://github.com/runfinch/finch/blob/ff1346b1d76f083ba86433e4501cbb5e5ce29634/cmd/finch/nerdctl_windows.go#L72. The same logic is reused here so that these tests can be run without depending on Finch CLI.
- This is needed by https://github.com/runfinch/finch-core/pull/969 which enables running e2e tests on Windows without the Finch CLI (directly with `limactl`) to test newer OS images.

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.